### PR TITLE
Restructure API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,9 @@ schannel = "0.1"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
 openssl = "0.8.2"
-openssl-verify = "0.2"
 
 [dev-dependencies]
 openssl = "0.8.2"
-openssl-verify = "0.2"
 
 [replace]
 "schannel:0.1.0" = { git = "https://github.com/steffengy/schannel-rs" }
@@ -30,4 +28,3 @@ openssl-verify = "0.2"
 "security-framework-sys:0.1.8" = { git = "https://github.com/sfackler/rust-security-framework" }
 "openssl:0.8.3" = { git = "https://github.com/sfackler/rust-openssl" }
 "openssl-sys:0.7.17" = { git = "https://github.com/sfackler/rust-openssl" }
-"openssl-verify:0.2.0" = { git = "https://github.com/sfackler/rust-openssl-verify" }

--- a/src/backend/openssl.rs
+++ b/src/backend/openssl.rs
@@ -1,3 +1,3 @@
 //! OpenSSL-specific functionality.
 
-pub use imp::{ClientBuilderExt, ServerBuilderExt, TlsStreamExt};
+pub use imp::{TlsConnectorBuilderExt, TlsAcceptorBuilderExt, TlsStreamExt};


### PR DESCRIPTION
Use high level OpenSSL wrappers for configuration logic as well.

cc @alexcrichton Not totally sold on the naming here, but I can't really think of anything better.