### PR TITLE
Derive Clone interface for Pkcs12

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -68,6 +68,7 @@ impl From<ErrorStack> for Error {
     }
 }
 
+#[derive(Clone)]
 pub struct Pkcs12(pkcs12::ParsedPkcs12);
 
 impl Pkcs12 {

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -52,6 +52,7 @@ impl From<io::Error> for Error {
     }
 }
 
+#[derive(Clone)]
 pub struct Pkcs12 {
     cert: CertContext,
 }

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -72,6 +72,7 @@ impl From<base::Error> for Error {
     }
 }
 
+#[derive(Clone)]
 pub struct Pkcs12 {
     identity: SecIdentity,
     chain: Vec<SecCertificate>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ impl From<imp::Error> for Error {
 }
 
 /// A PKCS #12 archive.
+#[derive(Clone)]
 pub struct Pkcs12(imp::Pkcs12);
 
 impl Pkcs12 {


### PR DESCRIPTION
Because `TlsConnectorBuilder::identity` consumes its `Pkcs12` argument, this derives the Clone trait to avoid re-parsing.