### PR TITLE
Expose a few more details of underlying backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ documentation = "https://docs.rs/native-tls/0.1.0/native_tls"
 readme = "README.md"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = { version = "0.1.9", features = ["OSX_10_8"] }
-security-framework-sys = "0.1.9"
+security-framework = { version = "0.1.10", features = ["OSX_10_8"] }
+security-framework-sys = "0.1.10"
 tempdir = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/backend/openssl.rs
+++ b/src/backend/openssl.rs
@@ -1,3 +1,4 @@
 //! OpenSSL-specific functionality.
 
 pub use imp::{TlsConnectorBuilderExt, TlsAcceptorBuilderExt, TlsStreamExt};
+pub use imp::ErrorExt;

--- a/src/backend/schannel.rs
+++ b/src/backend/schannel.rs
@@ -1,3 +1,4 @@
 //! SChannel-specific functionality.
 
 pub use imp::TlsStreamExt;
+pub use imp::ErrorExt;

--- a/src/backend/security_framework.rs
+++ b/src/backend/security_framework.rs
@@ -1,3 +1,5 @@
 //! Security Framework-specific functionality.
 
 pub use imp::TlsStreamExt;
+pub use imp::TlsConnectorBuilderExt;
+pub use imp::ErrorExt;

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -315,3 +315,15 @@ impl<S> TlsStreamExt<S> for ::TlsStream<S> {
         &mut (self.0).0
     }
 }
+
+/// OpenSSL-specific extensions to `Error`
+pub trait ErrorExt {
+    /// Extract the underlying OpenSSL error for inspection.
+    fn openssl_error(&self) -> &ssl::Error;
+}
+
+impl ErrorExt for ::Error {
+    fn openssl_error(&self) -> &ssl::Error {
+        &(self.0).0
+    }
+}

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -285,3 +285,15 @@ impl<S> TlsStreamExt<S> for ::TlsStream<S> {
         &mut (self.0).0
     }
 }
+
+/// SChannel-specific extensions to `Error`
+pub trait ErrorExt {
+    /// Extract the underlying SChannel error for inspection.
+    fn schannel_error(&self) -> &io::Error;
+}
+
+impl ErrorExt for ::Error {
+    fn schannel_error(&self) -> &io::Error {
+        &(self.0).0
+    }
+}


### PR DESCRIPTION
This commit updates the various backends to export some more information, where
all of these changes were motivated in getting the tokio-tls test suite running
again. (it's just a bunch of smoke tests really). A summary of the changes are:

* Add an `ErrorExt` trait to each backend to lower a `native_tls::Error` to the
  backend-specific error. This allows inspection of errors codes and such if
  necessary.

* Add `TlsConnectorBuilderExt` to the `security_framework` backend, with one
  function called `anchor_certificates`. This function transitively calls the
  security framework crate's `anchor_certificates` function to set a custom
  trusted certificate for a connection. Along the way this required using the
  `ClientBuilder` type which in turn required changes to work with async I/O.

The changes to the security framework side of things forces this crate to depend
on the changes in sfackler/rust-security-framework#23, so it shouldn't be merged
before that's updated and released!