### PR TITLE
Read android certs from /system/etc/security/cacerts

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -180,7 +180,29 @@ pub struct TlsConnector(SslConnector);
 
 impl TlsConnector {
     pub fn builder() -> Result<TlsConnectorBuilder, Error> {
-        let builder = try!(SslConnectorBuilder::new(SslMethod::tls()));
+        let mut builder = try!(SslConnectorBuilder::new(SslMethod::tls()));
+        // Add android root certs
+
+        #[cfg(target_os = "android")]
+        {
+            use std::fs;
+            use std::io::Read;
+
+            let mut cert_store = builder.builder_mut().cert_store_mut();
+
+            if let Ok(certs) = fs::read_dir("/system/etc/security/cacerts") {
+                for entry in certs.filter_map(|r| r.ok()).filter(|e| e.path().is_file()) {
+                    let mut cert = String::new();
+                    if let Ok(_) = fs::File::open(entry.path())
+                            .and_then(|mut f| f.read_to_string(&mut cert)) {
+                        if let Ok(cert) = X509::from_pem(cert.as_bytes()) {
+                            try!(cert_store.add_cert(cert));
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(TlsConnectorBuilder(builder))
     }
 


### PR DESCRIPTION
This is a port of https://github.com/sfackler/rust-openssl/issues/610 to rust-native-tls. 