### PR TITLE
Make acceptors and connectors cloneable

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -176,6 +176,7 @@ impl TlsConnectorBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct TlsConnector(SslConnector);
 
 impl TlsConnector {
@@ -231,6 +232,7 @@ impl TlsAcceptorBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct TlsAcceptor(SslAcceptor);
 
 impl TlsAcceptor {

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -165,6 +165,7 @@ impl TlsConnectorBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct TlsConnector {
     cert: Option<CertContext>,
     roots: CertStore,
@@ -232,6 +233,7 @@ impl TlsAcceptorBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct TlsAcceptor {
     cert: CertContext,
     protocols: Vec<Protocol>,

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -71,6 +71,7 @@ impl From<base::Error> for Error {
     }
 }
 
+#[derive(Clone)]
 pub struct Pkcs12 {
     identity: SecIdentity,
     chain: Vec<SecCertificate>,

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -224,6 +224,7 @@ impl TlsConnectorBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct TlsConnector {
     pkcs12: Option<Pkcs12>,
     protocols: Vec<Protocol>,
@@ -293,6 +294,7 @@ impl TlsAcceptorBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct TlsAcceptor {
     pkcs12: Pkcs12,
     protocols: Vec<Protocol>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,7 @@ impl TlsConnectorBuilder {
 /// stream.read_to_end(&mut res).unwrap();
 /// println!("{}", String::from_utf8_lossy(&res));
 /// ```
+#[derive(Clone)]
 pub struct TlsConnector(imp::TlsConnector);
 
 impl TlsConnector {
@@ -469,6 +470,7 @@ impl TlsAcceptorBuilder {
 ///     }
 /// }
 /// ```
+#[derive(Clone)]
 pub struct TlsAcceptor(imp::TlsAcceptor);
 
 impl TlsAcceptor {


### PR DESCRIPTION
Building a TlsAcceptor or TlsConnector can be non trivial, so cloning allows easy reuse without having to rebuild from scratch.