### PR TITLE
specify verification callbacks for schannel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ security-framework-sys = "0.1.13"
 tempdir = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.3"
+schannel = "0.1.7"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
 openssl = "0.9.2"

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -313,18 +313,17 @@ impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
 }
 
 // SChannel-specific verification callback for validating failed certificate checks
-pub trait TlsConnectorBuilderCallbackExt {
+pub trait TlsConnectorBuilderExt {
     /// Callback function that determines whether certificate validation failures that occur when establishing connections
     /// should be overridden. The closure should return Ok if the validation failure is to be overridden.
-    fn callback<F>(&mut self, callback: F) ->  Result<(), Error> 
+    fn verify_callback<F>(&mut self, callback: F) 
         where F: Fn(tls_stream::CertValidationResult) -> io::Result<()> + 'static + Send + Sync;
 }
 
-impl TlsConnectorBuilderCallbackExt for ::TlsConnectorBuilder {
-    fn callback<F>(&mut self, callback: F) ->  Result<(), Error>
+impl TlsConnectorBuilderExt for ::TlsConnectorBuilder {
+    fn verify_callback<F>(&mut self, callback: F)
         where F: Fn(tls_stream::CertValidationResult) -> io::Result<()> + 'static + Send + Sync {
             (self.0).0.callback = Some(Arc::new(callback));
-            Ok(())
     }
 }
 

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -3,6 +3,7 @@ extern crate schannel;
 use std::io;
 use std::fmt;
 use std::error;
+use std::sync::Arc;
 use self::schannel::cert_store::{PfxImportOptions, Memory, CertStore, CertAdd};
 use self::schannel::cert_context::CertContext;
 use self::schannel::schannel_cred::{Direction, SchannelCred, Protocol};
@@ -170,6 +171,7 @@ pub struct TlsConnector {
     cert: Option<CertContext>,
     roots: CertStore,
     protocols: Vec<Protocol>,
+    callback: Option<Arc<Fn(tls_stream::CertValidationResult) -> io::Result<()> + Sync + Send>>,
 }
 
 impl TlsConnector {
@@ -178,6 +180,7 @@ impl TlsConnector {
             cert: None,
             roots: try!(Memory::new()).into_store(),
             protocols: vec![Protocol::Tls10, Protocol::Tls11, Protocol::Tls12],
+            callback: None,
         }))
     }
 
@@ -211,6 +214,10 @@ impl TlsConnector {
         let mut builder = tls_stream::Builder::new();
         if let Some(domain) = domain {
             builder.domain(domain);
+        }
+        if let Some(ref callback) = self.callback {
+            let callback = callback.clone();
+            builder.verify_callback(move |r| callback(r));
         }
         builder.cert_store(self.roots.clone());
         match builder.connect(cred, stream) {
@@ -302,6 +309,22 @@ impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()
+    }
+}
+
+// SChannel-specific verification callback for validating failed certificate checks
+pub trait TlsConnectorBuilderCallbackExt {
+    /// Callback function that determines whether certificate validation failures that occur when establishing connections
+    /// should be overridden. The closure should return Ok if the validation failure is to be overridden.
+    fn callback<F>(&mut self, callback: F) ->  Result<(), Error> 
+        where F: Fn(tls_stream::CertValidationResult) -> io::Result<()> + 'static + Send + Sync;
+}
+
+impl TlsConnectorBuilderCallbackExt for ::TlsConnectorBuilder {
+    fn callback<F>(&mut self, callback: F) ->  Result<(), Error>
+        where F: Fn(tls_stream::CertValidationResult) -> io::Result<()> + 'static + Send + Sync {
+            (self.0).0.callback = Some(Arc::new(callback));
+            Ok(())
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Write};
 use std::net::{TcpStream, TcpListener};
 use std::thread;
+use imp::TlsConnectorBuilderCallbackExt;
 
 use super::*;
 
@@ -173,6 +174,36 @@ fn server_untrusted() {
     let builder = p!(TlsConnector::builder());
     let builder = p!(builder.build());
     builder.connect("foobar.com", socket).unwrap_err();
+
+    p!(j.join());
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn schannel_verify_callback() {
+    let buf = include_bytes!("../test/identity.p12");
+    let pkcs12 = p!(Pkcs12::from_der(buf, "mypass"));
+    let builder = p!(TlsAcceptor::builder(pkcs12));
+    let builder = p!(builder.build());
+
+    let listener = p!(TcpListener::bind("0.0.0.0:0"));
+    let port = p!(listener.local_addr()).port();
+
+    let j = thread::spawn(move || {
+        let socket = p!(listener.accept()).0;
+        // FIXME should assert error
+        // https://github.com/steffengy/schannel-rs/issues/20
+        let _ = builder.accept(socket);
+    });
+
+    let socket = p!(TcpStream::connect(("localhost", port)));
+    let mut builder = p!(TlsConnector::builder());
+    p!(builder.callback(|validation_result| {
+                                        assert!(validation_result.result().is_err());
+                                        Ok(())
+                                    }));
+    let builder = p!(builder.build());
+    builder.connect("foobar.com", socket).unwrap();
 
     p!(j.join());
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 use std::net::{TcpStream, TcpListener};
 use std::thread;
-use imp::TlsConnectorBuilderCallbackExt;
+use imp::TlsConnectorBuilderExt;
 
 use super::*;
 
@@ -198,10 +198,10 @@ fn schannel_verify_callback() {
 
     let socket = p!(TcpStream::connect(("localhost", port)));
     let mut builder = p!(TlsConnector::builder());
-    p!(builder.callback(|validation_result| {
+    builder.verify_callback(|validation_result| {
                                         assert!(validation_result.result().is_err());
                                         Ok(())
-                                    }));
+                                    });
     let builder = p!(builder.build());
     builder.connect("foobar.com", socket).unwrap();
 


### PR DESCRIPTION
adds a trait in the connectorBuilder that allows users to specify a
verification callback to use in the event that a new connection's
validation fails