### PR TITLE
Enable conversion from internal errors to Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,9 +155,9 @@ impl fmt::Debug for Error {
     }
 }
 
-impl From<imp::Error> for Error {
-    fn from(err: imp::Error) -> Error {
-        Error(err)
+impl<T: Into<imp::Error>> From<T> for Error {
+    fn from(err: T) -> Error {
+        Error(err.into())
     }
 }
 


### PR DESCRIPTION
This allows making a `native_tls::Error` from e.g. a `openssl::error::ErrorStack`. Previously you'd have to do `.into().into()`, but type inference wasn't smart enough to figure this out.

Note this works because of the blanket `impl Into<T> for T`.