### PR TITLE
Update lazy_static to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/native-tls/0.1.4/native_tls"
 readme = "README.md"
 
 [dependencies]
-lazy_static = "0.2"
+lazy_static = "1.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 security-framework = { version = "0.1.15", features = ["OSX_10_8" ]}


### PR DESCRIPTION
This PR is similar to https://github.com/sfackler/rust-native-tls/pull/68 but only updates the `lazy_static` dep to avoid breaking the build.

Tests passing on Windows and Ubuntu.