### PR TITLE
Android add certs error: already in hash table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ lazy_static = "1.0"
 libc = "0.2"
 tempfile = "3.0"
 
+[target.'cfg(target_os = "android")'.dependencies]
+log = "0.4.5"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.13"
 

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -103,7 +103,7 @@ fn load_android_root_certs(connector: &mut SslContextBuilder) -> Result<(), Erro
             .filter_map(|b| X509::from_pem(&b).ok());
         for cert in certs {
             if let Err(err) = connector.cert_store_mut().add_cert(cert) {
-                eprintln!("load_android_root_certs error: {:?}", err);
+                debug!("load_android_root_certs error: {:?}", err);
             }
         }
     }

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -102,7 +102,9 @@ fn load_android_root_certs(connector: &mut SslContextBuilder) -> Result<(), Erro
             .filter_map(|e| fs::read(e.path()).ok())
             .filter_map(|b| X509::from_pem(&b).ok());
         for cert in certs {
-            connector.cert_store_mut().add_cert(cert)?;
+            if let Err(err) = connector.cert_store_mut().add_cert(cert) {
+                eprintln!("load_android_root_certs error: {:?}", err);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,9 @@ use std::fmt;
 use std::io;
 use std::result;
 
+#[cfg(target_os = "android")]
+#[macro_use]
+extern crate log;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[path = "imp/security_framework.rs"]
 mod imp;


### PR DESCRIPTION
Adding cert on android print error instead of crash

Now when load_android_root_certs failed, it'll print error instead of return error.

ErrorStack([Error { code: 185057381, library: "x509 certificate routines", function: "X509_STORE_add_cert", reason: "cert already in hash table", file: "crypto/x509/x509_lu.c", line: 326 }])

Without, I don't know how can I use hyper_tls on android with certs duplicated