### PR TITLE
Reverse chain loading for openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.5"
 schannel = "0.1.13"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
-openssl = "0.10.11"
+openssl = "0.10.15"
 openssl-sys = "0.9.30"
 openssl-probe = "0.1"
 

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -255,7 +255,7 @@ impl TlsConnector {
             connector.set_certificate(&(identity.0).0.cert)?;
             connector.set_private_key(&(identity.0).0.pkey)?;
             if let Some(ref chain) = (identity.0).0.chain {
-                for cert in chain {
+                for cert in chain.iter().rev() {
                     connector.add_extra_chain_cert(cert.to_owned())?;
                 }
             }
@@ -304,7 +304,7 @@ impl TlsAcceptor {
         acceptor.set_private_key(&(builder.identity.0).0.pkey)?;
         acceptor.set_certificate(&(builder.identity.0).0.cert)?;
         if let Some(ref chain) = (builder.identity.0).0.chain {
-            for cert in chain {
+            for cert in chain.iter().rev() {
                 acceptor.add_extra_chain_cert(cert.to_owned())?;
             }
         }


### PR DESCRIPTION
The stack is the reverse of what you might expect due to the way
PKCS12_parse is implemented, so we need to load it backwards.

Closes #110