### PR TITLE
TlsStream::certificate_chain, ChainIterator type and Certificate::public_key_info_der

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = {path = "../rust-security-framework/security-framework"}
-security-framework-sys = {path = "../rust-security-framework/security-framework-sys", features = ["OSX_10_13"]}
+security-framework = {git = "https://github.com/SergejJurecko/rust-security-framework"}
+security-framework-sys = {git = "https://github.com/SergejJurecko/rust-security-framework", features = ["OSX_10_13"]}
 core-foundation-sys = "0.6.2"
 core-foundation = "0.6.3"
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = {git = "https://github.com/SergejJurecko/rust-security-framework"}
-security-framework-sys = {git = "https://github.com/SergejJurecko/rust-security-framework", features = ["OSX_10_13"]}
+security-framework = "0.2.4-beta"
+security-framework-sys = {version = "0.2.4-beta", features = ["OSX_10_13"]}
 core-foundation-sys = "0.6.2"
 core-foundation = "0.6.3"
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 tempfile = "3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.13"
+schannel = {path = "../schannel-rs"}
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "0.2.4-beta"
-security-framework-sys = {version = "0.2.4-beta", features = ["OSX_10_13"]}
+security-framework = {git = "https://github.com/sergejjurecko/rust-security-framework/", features = ["OSX_10_12"]}
+security-framework-sys = {git = "https://github.com/sergejjurecko/rust-security-framework/", features = ["OSX_10_12"]}
 core-foundation-sys = "0.6.2"
 core-foundation = "0.6.3"
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 tempfile = "3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = {path = "../schannel-rs"}
+schannel = {path = "https://github.com/SergejJurecko/schannel-rs"}
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 tempfile = "3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = {path = "https://github.com/SergejJurecko/schannel-rs"}
+schannel = {git = "https://github.com/SergejJurecko/schannel-rs"}
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "0.2.1"
-security-framework-sys = "0.2.1"
+security-framework = {path = "../rust-security-framework/security-framework"}
+security-framework-sys = {path = "../rust-security-framework/security-framework-sys", features = ["OSX_10_13"]}
+core-foundation-sys = "0.6.2"
+core-foundation = "0.6.3"
 lazy_static = "1.0"
 libc = "0.2"
 tempfile = "3.0"

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -9,7 +9,8 @@ use self::openssl::ssl::{
     self, MidHandshakeSslStream, SslAcceptor, SslConnector, SslContextBuilder, SslMethod,
     SslVerifyMode,
 };
-use self::openssl::x509::{X509, X509VerifyResult};
+use self::openssl::stack;
+use self::openssl::x509::{X509VerifyResult, X509};
 use std::error;
 use std::fmt;
 use std::io;
@@ -330,6 +331,19 @@ impl TlsAcceptor {
     }
 }
 
+pub struct ChainIterator<'a, S: 'a>(Option<stack::Iter<'a, X509>>, &'a TlsStream<S>);
+
+impl<'a, S> Iterator for ChainIterator<'a, S> {
+    type Item = Certificate;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(i) = self.0.as_mut() {
+            return i.next().map(|c| Certificate(c.to_owned()));
+        }
+        None
+    }
+}
+
 pub struct TlsStream<S>(ssl::SslStream<S>);
 
 impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
@@ -353,6 +367,13 @@ impl<S: io::Read + io::Write> TlsStream<S> {
 
     pub fn peer_certificate(&self) -> Result<Option<Certificate>, Error> {
         Ok(self.0.ssl().peer_certificate().map(Certificate))
+    }
+
+    pub fn certificate_chain(&self) -> Result<ChainIterator<S>, Error> {
+        Ok(ChainIterator(
+            self.0.ssl().peer_cert_chain().map(|stack| stack.iter()),
+            self,
+        ))
     }
 
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -179,7 +179,7 @@ impl Certificate {
         Ok(der)
     }
 
-    pub fn public_key_der(&self) -> Result<Vec<u8>, Error> {
+    pub fn public_key_info_der(&self) -> Result<Vec<u8>, Error> {
         let pk = self.0.public_key()?;
         let der = pk.public_key_to_der()?;
         Ok(der)

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -369,7 +369,7 @@ impl<S: io::Read + io::Write> TlsStream<S> {
         Ok(self.0.ssl().peer_certificate().map(Certificate))
     }
 
-    pub fn certificate_chain(&self) -> Result<ChainIterator<S>, Error> {
+    pub fn certificate_chain(&mut self) -> Result<ChainIterator<S>, Error> {
         Ok(ChainIterator(
             self.0.ssl().peer_cert_chain().map(|stack| stack.iter()),
             self,

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -177,6 +177,12 @@ impl Certificate {
         let der = self.0.to_der()?;
         Ok(der)
     }
+
+    pub fn public_key_der(&self) -> Result<Vec<u8>, Error> {
+        let pk = self.0.public_key()?;
+        let der = pk.public_key_to_der()?;
+        Ok(der)
+    }
 }
 
 pub struct MidHandshakeTlsStream<S>(MidHandshakeSslStream<S>);

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -124,7 +124,7 @@ impl Certificate {
     }
 
     pub fn public_key_der(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.0.subject_public_key_info_der())
+        Ok(self.0.subject_public_key_info_der()?)
     }
 }
 

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -122,6 +122,10 @@ impl Certificate {
     pub fn to_der(&self) -> Result<Vec<u8>, Error> {
         Ok(self.0.to_der().to_vec())
     }
+
+    pub fn public_key_der(&self) -> Result<Vec<u8>, Error> {
+        Ok(self.0.subject_public_key_info_der())
+    }
 }
 
 pub struct MidHandshakeTlsStream<S>(tls_stream::MidHandshakeTlsStream<S>);

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -125,7 +125,7 @@ impl Certificate {
         Ok(self.0.to_der().to_vec())
     }
 
-    pub fn public_key_der(&self) -> Result<Vec<u8>, Error> {
+    pub fn public_key_info_der(&self) -> Result<Vec<u8>, Error> {
         Ok(self.0.subject_public_key_info_der()?)
     }
 }

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -5,13 +5,6 @@ extern crate security_framework;
 extern crate security_framework_sys;
 extern crate tempfile;
 
-use self::core_foundation::base::TCFType;
-use self::core_foundation_sys::base::{CFComparisonResult, CFRelease};
-use self::core_foundation_sys::data::{CFDataGetBytePtr, CFDataGetLength};
-use self::core_foundation_sys::dictionary::CFDictionaryGetValueIfPresent;
-use self::core_foundation_sys::error::CFErrorRef;
-use self::core_foundation_sys::number::{kCFNumberSInt32Type, CFNumberGetValue};
-use self::core_foundation_sys::string::{CFStringCompareFlags, CFStringRef};
 use self::security_framework::certificate::SecCertificate;
 use self::security_framework::identity::SecIdentity;
 use self::security_framework::import_export::{ImportedIdentity, Pkcs12ImportOptions};
@@ -19,19 +12,13 @@ use self::security_framework::secure_transport::{
     self, ClientBuilder, SslConnectionType, SslContext, SslProtocol, SslProtocolSide,
 };
 use self::security_framework::{base, trust::SecTrust};
-use self::security_framework_sys::base::{errSecIO, SecKeyRef, SecPolicyRef};
-use self::security_framework_sys::item::*;
-use self::security_framework_sys::key::{SecKeyCopyAttributes, SecKeyCopyExternalRepresentation};
-use self::security_framework_sys::policy::SecPolicyCreateBasicX509;
-use self::security_framework_sys::trust::{
-    SecTrustCopyPublicKey, SecTrustCreateWithCertificates, SecTrustEvaluate, SecTrustRef,
-    SecTrustResultType,
-};
+use self::security_framework_sys::base::errSecIO;
+
 use self::tempfile::TempDir;
 use std::error;
 use std::fmt;
 use std::io;
-use std::ptr;
+
 use std::sync::Mutex;
 use std::sync::{Once, ONCE_INIT};
 
@@ -192,77 +179,8 @@ impl Certificate {
         Ok(self.0.to_der())
     }
 
-    // Ported from TrustKit pinning implementation
-    // https://github.com/datatheorem/TrustKit/blob/master/TrustKit/Pinning/TSKSPKIHashCache.m
-    pub fn public_key_der(&self) -> Result<Vec<u8>, Error> {
-        unsafe {
-            let k = self.copy_public_key_from_certificate();
-            let mut error: CFErrorRef = std::ptr::null_mut();
-            let public_key_data = SecKeyCopyExternalRepresentation(k, &mut error);
-            if public_key_data == ptr::null_mut() {
-                CFRelease(k as _);
-                return Err(Error::from(base::Error::from_code(0)));
-            }
-            let public_key_attributes = SecKeyCopyAttributes(k);
-
-            let mut public_key_type: *const std::os::raw::c_void = ptr::null();
-            CFDictionaryGetValueIfPresent(
-                public_key_attributes,
-                kSecAttrKeyType as _,
-                &mut public_key_type as _,
-            );
-            let mut public_keysize: *const std::os::raw::c_void = ptr::null();
-            CFDictionaryGetValueIfPresent(
-                public_key_attributes,
-                kSecAttrKeySizeInBits as _,
-                &mut public_keysize as *mut *const std::os::raw::c_void,
-            );
-            CFRelease(public_key_attributes as _);
-            let mut public_keysize_val: u32 = 0;
-            let public_keysize_val_ptr: *mut u32 = &mut public_keysize_val;
-            CFNumberGetValue(
-                public_keysize as _,
-                kCFNumberSInt32Type,
-                public_keysize_val_ptr as _,
-            );
-            let hdr_bytes = get_asn1_header_bytes(public_key_type as _, public_keysize_val);
-            if hdr_bytes.len() == 0 {
-                return Err(Error::from(base::Error::from_code(0)));
-            }
-            CFRelease(k as _);
-            let key_data_len = CFDataGetLength(public_key_data) as usize;
-            let key_data_slice = std::slice::from_raw_parts(
-                CFDataGetBytePtr(public_key_data) as *const u8,
-                key_data_len,
-            );
-            let mut out = Vec::with_capacity(hdr_bytes.len() + key_data_len);
-            out.extend_from_slice(hdr_bytes);
-            out.extend_from_slice(key_data_slice);
-
-            CFRelease(public_key_data as _);
-            Ok(out)
-        }
-    }
-
-    fn copy_public_key_from_certificate(&self) -> SecKeyRef {
-        unsafe {
-            // Create an X509 trust using the using the certificate
-            let mut trust: SecTrustRef = ptr::null_mut();
-            let policy: SecPolicyRef = SecPolicyCreateBasicX509();
-            SecTrustCreateWithCertificates(
-                self.0.as_concrete_TypeRef() as _,
-                policy as _,
-                &mut trust,
-            );
-
-            // Get a public key reference for the certificate from the trust
-            let mut result: SecTrustResultType = 0;
-            SecTrustEvaluate(trust, &mut result);
-            let public_key = SecTrustCopyPublicKey(trust);
-            CFRelease(policy as _);
-            CFRelease(trust as _);
-            public_key
-        }
+    pub fn public_key_info_der(&self) -> Result<Vec<u8>, Error> {
+        Ok(self.0.public_key_info_der()?.unwrap_or(Vec::new()))
     }
 }
 
@@ -662,47 +580,4 @@ extern "C" {
     fn CC_SHA256(data: *const u8, len: CC_LONG, md: *mut u8) -> *mut u8;
     fn CC_SHA384(data: *const u8, len: CC_LONG, md: *mut u8) -> *mut u8;
     fn CC_SHA512(data: *const u8, len: CC_LONG, md: *mut u8) -> *mut u8;
-    fn CFStringCompare(
-        theString1: CFStringRef,
-        theString2: CFStringRef,
-        compareOptions: CFStringCompareFlags,
-    ) -> CFComparisonResult;
 }
-
-fn get_asn1_header_bytes(pkt: CFStringRef, ksz: u32) -> &'static [u8] {
-    unsafe {
-        if CFStringCompare(pkt, kSecAttrKeyTypeRSA, 0) as i64 == 0 && ksz == 2048 {
-            return &RSA_2048_ASN1_HEADER;
-        }
-        if CFStringCompare(pkt, kSecAttrKeyTypeRSA, 0) as i64 == 0 && ksz == 4096 {
-            return &RSA_4096_ASN1_HEADER;
-        }
-        if CFStringCompare(pkt, kSecAttrKeyTypeECSECPrimeRandom, 0) as i64 == 0 && ksz == 256 {
-            return &EC_DSA_SECP_256_R1_ASN1_HEADER;
-        }
-        if CFStringCompare(pkt, kSecAttrKeyTypeECSECPrimeRandom, 0) as i64 == 0 && ksz == 384 {
-            return &EC_DSA_SECP_384_R1_ASN1_HEADER;
-        }
-    }
-    &[]
-}
-
-const RSA_2048_ASN1_HEADER: [u8; 24] = [
-    0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
-    0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00,
-];
-
-const RSA_4096_ASN1_HEADER: [u8; 24] = [
-    0x30, 0x82, 0x02, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
-    0x01, 0x05, 0x00, 0x03, 0x82, 0x02, 0x0f, 0x00,
-];
-
-const EC_DSA_SECP_256_R1_ASN1_HEADER: [u8; 26] = [
-    0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a,
-    0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
-];
-
-const EC_DSA_SECP_384_R1_ASN1_HEADER: [u8; 23] = [
-    0x30, 0x76, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x05, 0x2b,
-    0x81, 0x04, 0x00, 0x22, 0x03, 0x62, 0x00,
-];

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -493,7 +493,7 @@ impl<S: io::Read + io::Write> TlsStream<S> {
         Ok(trust.certificate_at_index(0).map(Certificate))
     }
 
-    pub fn certificate_chain(&self) -> Result<ChainIterator<S>, Error> {
+    pub fn certificate_chain(&mut self) -> Result<ChainIterator<S>, Error> {
         let trust = match self.stream.context().peer_trust2()? {
             Some(trust) => trust,
             None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,15 @@ impl Certificate {
     }
 }
 
+pub struct ChainIterator(imp::ChainIterator);
+impl Iterator for ChainIterator {
+    type Item = Certificate;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Certificate)
+    }
+}
+
 /// A TLS stream which has been interrupted midway through the handshake process.
 pub struct MidHandshakeTlsStream<S>(imp::MidHandshakeTlsStream<S>);
 
@@ -634,6 +643,11 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     /// Returns the peer's leaf certificate, if available.
     pub fn peer_certificate(&self) -> Result<Option<Certificate>> {
         Ok(self.0.peer_certificate()?.map(Certificate))
+    }
+
+    /// Returns an iterator over certificate chain, if available.
+    pub fn certificate_chain(&self) -> Result<ChainIterator> {
+        Ok(ChainIterator(self.0.certificate_chain()?))
     }
 
     /// Returns the tls-server-end-point channel binding data as defined in [RFC 5929].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,7 +648,7 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     }
 
     /// Returns an iterator over certificate chain, if available.
-    pub fn certificate_chain(&self) -> Result<ChainIterator<S>> {
+    pub fn certificate_chain(&mut self) -> Result<ChainIterator<S>> {
         Ok(ChainIterator(self.0.certificate_chain()?))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,12 @@ impl Certificate {
         let der = self.0.to_der()?;
         Ok(der)
     }
+
+    /// Returns der encoded SubjectPublicKeyInfo.
+    pub fn public_key_der(&self) -> Result<Vec<u8>> {
+        let der = self.0.public_key_der()?;
+        Ok(der)
+    }
 }
 
 /// A TLS stream which has been interrupted midway through the handshake process.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,9 +207,9 @@ impl Certificate {
         Ok(der)
     }
 
-    /// Returns der encoded SubjectPublicKeyInfo.
-    pub fn public_key_der(&self) -> Result<Vec<u8>> {
-        let der = self.0.public_key_der()?;
+    /// Returns der encoded subjectPublicKeyInfo.
+    pub fn public_key_info_der(&self) -> Result<Vec<u8>> {
+        let der = self.0.public_key_info_der()?;
         Ok(der)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,8 +214,10 @@ impl Certificate {
     }
 }
 
-pub struct ChainIterator(imp::ChainIterator);
-impl Iterator for ChainIterator {
+/// An iterator over a certificate chain.
+pub struct ChainIterator<'a, S: 'a>(imp::ChainIterator<'a, S>);
+
+impl<'a, S> Iterator for ChainIterator<'a, S> {
     type Item = Certificate;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -646,7 +648,7 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     }
 
     /// Returns an iterator over certificate chain, if available.
-    pub fn certificate_chain(&self) -> Result<ChainIterator> {
+    pub fn certificate_chain(&self) -> Result<ChainIterator<S>> {
         Ok(ChainIterator(self.0.certificate_chain()?))
     }
 


### PR DESCRIPTION
This patch makes certificate pinning possible on top of rust-native-tls. What is required is access to the entire certificate chain and subjectPublicKeyInfo part of a certificate.

This is not ready to be merged yet, as I am waiting for downstream schannel and rust-security-framework patches to be merged. 

I've created this PR now to resolve any blockers in the meantime. 