### PR TITLE
Update security-framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "0.2.1"
-security-framework-sys = "0.2.1"
+security-framework = "0.3.1"
+security-framework-sys = "0.3.1"
 lazy_static = "1.0"
 libc = "0.2"
 tempfile = "3.0"


### PR DESCRIPTION
It's compatible, the major bump is for a dependency only.