### PR TITLE
Add a possibility to create system-based Identity

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -115,6 +115,7 @@ fn load_android_root_certs(connector: &mut SslContextBuilder) -> Result<(), Erro
 pub enum Error {
     Normal(ErrorStack),
     Ssl(ssl::Error, X509VerifyResult),
+    Unsupported
 }
 
 impl error::Error for Error {
@@ -122,13 +123,16 @@ impl error::Error for Error {
         match *self {
             Error::Normal(ref e) => error::Error::description(e),
             Error::Ssl(ref e, _) => error::Error::description(e),
+            Error::Unsupported => "Unsupported",
         }
     }
 
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Normal(ref e) => error::Error::cause(e),
             Error::Ssl(ref e, _) => error::Error::cause(e),
+            Error::Unsupported => None
         }
     }
 }
@@ -139,6 +143,7 @@ impl fmt::Display for Error {
             Error::Normal(ref e) => fmt::Display::fmt(e, fmt),
             Error::Ssl(ref e, X509VerifyResult::OK) => fmt::Display::fmt(e, fmt),
             Error::Ssl(ref e, v) => write!(fmt, "{} ({})", e, v),
+            Error::Unsupported => write!(fmt, "Unsupported"),
         }
     }
 }
@@ -156,6 +161,10 @@ impl Identity {
         let pkcs12 = Pkcs12::from_der(buf)?;
         let parsed = pkcs12.parse(pass)?;
         Ok(Identity(parsed))
+    }
+
+    pub fn from_system() -> Result<Identity, Error> {
+        Err(Error::Unsupported)
     }
 }
 

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -101,7 +101,7 @@ impl Identity {
         Identity::from_store(store)
     }
 
-    fn from_system() -> Result<Identity, Error> {
+    pub fn from_system() -> Result<Identity, Error> {
         let store = CertStore::open_local_machine("my")?;
         Identity::from_store(store)
     }
@@ -200,15 +200,7 @@ pub struct TlsConnector {
 
 impl TlsConnector {
     pub fn new(builder: &TlsConnectorBuilder) -> Result<TlsConnector, Error> {
-        let mut cert = if builder.use_system_identity {
-            Identity::from_system().ok().map(|i| i.cert)
-        } else {
-            None
-        };
-
-        if cert.is_none() {
-            cert = builder.identity.as_ref().map(|i| i.0.cert.clone());
-        }
+        let cert = builder.identity.as_ref().map(|i| i.0.cert.clone());
 
         let mut roots = Memory::new()?.into_store();
         for cert in &builder.root_certificates {

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -48,7 +48,7 @@ fn convert_protocol(protocol: Protocol) -> SslProtocol {
     }
 }
 
-pub struct Error(base::Error::from_code(0));
+pub struct Error(base::Error);
 
 impl error::Error for Error {
     fn description(&self) -> &str {
@@ -108,7 +108,7 @@ impl Identity {
     }
 
     pub fn from_system() -> Result<Identity, Error> {
-        Err(Error))
+        Err(Error(base::Error::from_code(errSecParam)))
     }
 
     #[cfg(not(target_os = "ios"))]

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -48,7 +48,7 @@ fn convert_protocol(protocol: Protocol) -> SslProtocol {
     }
 }
 
-pub struct Error(base::Error);
+pub struct Error(base::Error::from_code(0));
 
 impl error::Error for Error {
     fn description(&self) -> &str {
@@ -105,6 +105,10 @@ impl Identity {
                 .filter(|c| c.to_der() != identity_cert)
                 .collect(),
         })
+    }
+
+    pub fn from_system() -> Result<Identity, Error> {
+        Err(Error))
     }
 
     #[cfg(not(target_os = "ios"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ impl error::Error for Error {
         error::Error::description(&self.0)
     }
 
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&error::Error> {
         error::Error::cause(&self.0)
     }
@@ -332,12 +333,20 @@ pub struct TlsConnectorBuilder {
     accept_invalid_certs: bool,
     accept_invalid_hostnames: bool,
     use_sni: bool,
+    use_system_identity: bool,
 }
 
 impl TlsConnectorBuilder {
     /// Sets the identity to be used for client certificate authentication.
     pub fn identity(&mut self, identity: Identity) -> &mut TlsConnectorBuilder {
         self.identity = Some(identity);
+        self
+    }
+
+    /// Use system certificate store (if available) for identity
+    /// If there is no system store or no identity available fall back to PKCS12 identity
+    pub fn use_system_identity(&mut self, use_system_identity: bool) -> &mut TlsConnectorBuilder {
+        self.use_system_identity = use_system_identity;
         self
     }
 
@@ -459,6 +468,7 @@ impl TlsConnector {
             use_sni: true,
             accept_invalid_certs: false,
             accept_invalid_hostnames: false,
+            use_system_identity: false,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,12 @@ impl Identity {
         let identity = imp::Identity::from_pkcs12(der, password)?;
         Ok(Identity(identity))
     }
+
+    /// Constructs a default system identity on supported platforms
+    pub fn from_system() -> Result<Identity> {
+        let identity = imp::Identity::from_system()?;
+        Ok(Identity(identity))
+    }
 }
 
 /// An X509 certificate.
@@ -333,20 +339,12 @@ pub struct TlsConnectorBuilder {
     accept_invalid_certs: bool,
     accept_invalid_hostnames: bool,
     use_sni: bool,
-    use_system_identity: bool,
 }
 
 impl TlsConnectorBuilder {
     /// Sets the identity to be used for client certificate authentication.
     pub fn identity(&mut self, identity: Identity) -> &mut TlsConnectorBuilder {
         self.identity = Some(identity);
-        self
-    }
-
-    /// Use system certificate store (if available) for identity
-    /// If there is no system store or no identity available fall back to PKCS12 identity
-    pub fn use_system_identity(&mut self, use_system_identity: bool) -> &mut TlsConnectorBuilder {
-        self.use_system_identity = use_system_identity;
         self
     }
 
@@ -468,7 +466,6 @@ impl TlsConnector {
             use_sni: true,
             accept_invalid_certs: false,
             accept_invalid_hostnames: false,
-            use_system_identity: false,
         }
     }
 


### PR DESCRIPTION
This PR adds Identity::from_system function. Currently only works on Windows; other platforms will return Error::Unsupported.

The rationale is that many enterprise applications *require* that the key chains must be taken from secure certificate store without the need to specify the store password.