### PR TITLE
Fix warnings

### DIFF
--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -38,8 +38,8 @@ impl error::Error for Error {
         error::Error::description(&self.0)
     }
 
-    fn cause(&self) -> Option<&error::Error> {
-        error::Error::cause(&self.0)
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        error::Error::source(&self.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,8 @@ impl error::Error for Error {
         error::Error::description(&self.0)
     }
 
-    fn cause(&self) -> Option<&error::Error> {
-        error::Error::cause(&self.0)
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        error::Error::source(&self.0)
     }
 }
 
@@ -272,7 +272,7 @@ where
         "handshake error"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             HandshakeError::Failure(ref e) => Some(e),
             HandshakeError::WouldBlock(_) => None,


### PR DESCRIPTION
```
warning: trait objects without an explicit `dyn` are deprecated
  --> src\imp\schannel.rs:41:32
   |
41 |     fn cause(&self) -> Option<&error::Error> {
   |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`
   |
   = note: #[warn(bare_trait_objects)] on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> src\lib.rs:139:32
    |
139 |     fn cause(&self) -> Option<&error::Error> {
    |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`

warning: trait objects without an explicit `dyn` are deprecated
   --> src\lib.rs:275:32
    |
275 |     fn cause(&self) -> Option<&error::Error> {
    |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`

warning: use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting
   --> src\lib.rs:140:9
    |
140 |         error::Error::cause(&self.0)
    |         ^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default

warning: use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting
  --> src\imp\schannel.rs:42:9
   |
42 |         error::Error::cause(&self.0)
   |         ^^^^^^^^^^^^^^^^^^^
```