### PR TITLE
Relax bounds for get_ref and get_mut

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,6 @@ workflows:
     jobs:
       - linux:
           name: openssl
-          image: 1.31.0-stretch
+          image: 1.32.0-stretch
       - macos:
-          version: 1.31.0
+          version: 1.32.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,6 @@ workflows:
     jobs:
       - linux:
           name: openssl
-          image: 1.30.0-stretch
+          image: 1.31.0-stretch
       - macos:
-          version: 1.30.0
+          version: 1.31.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 tempfile = "3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.13"
+schannel = "0.1.16"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  RUST_VERSION: 1.30.0
+  RUST_VERSION: 1.31.0
   TARGET: x86_64-pc-windows-msvc
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:TARGET}.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  RUST_VERSION: 1.31.0
+  RUST_VERSION: 1.32.0
   TARGET: x86_64-pc-windows-msvc
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:TARGET}.exe"

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -332,7 +332,7 @@ impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
     }
 }
 
-impl<S: io::Read + io::Write> TlsStream<S> {
+impl<S> TlsStream<S> {
     pub fn get_ref(&self) -> &S {
         self.0.get_ref()
     }
@@ -340,7 +340,9 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn get_mut(&mut self) -> &mut S {
         self.0.get_mut()
     }
+}
 
+impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn buffered_read_size(&self) -> Result<usize, Error> {
         Ok(self.0.ssl().pending())
     }

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -135,10 +135,7 @@ where
     }
 }
 
-impl<S> MidHandshakeTlsStream<S>
-where
-    S: io::Read + io::Write,
-{
+impl<S> MidHandshakeTlsStream<S> {
     pub fn get_ref(&self) -> &S {
         self.0.get_ref()
     }
@@ -146,7 +143,12 @@ where
     pub fn get_mut(&mut self) -> &mut S {
         self.0.get_mut()
     }
+}
 
+impl<S> MidHandshakeTlsStream<S>
+where
+    S: io::Read + io::Write,
+{
     pub fn handshake(self) -> Result<TlsStream<S>, HandshakeError<S>> {
         match self.0.handshake() {
             Ok(s) => Ok(TlsStream(s)),
@@ -273,7 +275,7 @@ impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
     }
 }
 
-impl<S: io::Read + io::Write> TlsStream<S> {
+impl<S> TlsStream<S> {
     pub fn get_ref(&self) -> &S {
         self.0.get_ref()
     }
@@ -281,7 +283,9 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn get_mut(&mut self) -> &mut S {
         self.0.get_mut()
     }
+}
 
+impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn buffered_read_size(&self) -> Result<usize, Error> {
         Ok(self.0.get_buf().len())
     }

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -218,10 +218,7 @@ where
     }
 }
 
-impl<S> MidHandshakeTlsStream<S>
-where
-    S: io::Read + io::Write,
-{
+impl<S> MidHandshakeTlsStream<S> {
     pub fn get_ref(&self) -> &S {
         match *self {
             MidHandshakeTlsStream::Server(ref s, _) => s.get_ref(),
@@ -235,7 +232,12 @@ where
             MidHandshakeTlsStream::Client(ref mut s) => s.get_mut(),
         }
     }
+}
 
+impl<S> MidHandshakeTlsStream<S>
+where
+    S: io::Read + io::Write,
+{
     pub fn handshake(self) -> Result<TlsStream<S>, HandshakeError<S>> {
         match self {
             MidHandshakeTlsStream::Server(s, cert) => match s.handshake() {
@@ -362,7 +364,7 @@ impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
     }
 }
 
-impl<S: io::Read + io::Write> TlsStream<S> {
+impl<S> TlsStream<S> {
     pub fn get_ref(&self) -> &S {
         self.stream.get_ref()
     }
@@ -370,7 +372,9 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn get_mut(&mut self) -> &mut S {
         self.stream.get_mut()
     }
+}
 
+impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn buffered_read_size(&self) -> Result<usize, Error> {
         Ok(self.stream.context().buffered_read_size()?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,10 +220,7 @@ where
     }
 }
 
-impl<S> MidHandshakeTlsStream<S>
-where
-    S: io::Read + io::Write,
-{
+impl<S> MidHandshakeTlsStream<S> {
     /// Returns a shared reference to the inner stream.
     pub fn get_ref(&self) -> &S {
         self.0.get_ref()
@@ -233,7 +230,12 @@ where
     pub fn get_mut(&mut self) -> &mut S {
         self.0.get_mut()
     }
+}
 
+impl<S> MidHandshakeTlsStream<S>
+where
+    S: io::Read + io::Write,
+{
     /// Restarts the handshake process.
     ///
     /// If the handshake completes successfully then the negotiated stream is
@@ -608,7 +610,7 @@ impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
     }
 }
 
-impl<S: io::Read + io::Write> TlsStream<S> {
+impl<S> TlsStream<S> {
     /// Returns a shared reference to the inner stream.
     pub fn get_ref(&self) -> &S {
         self.0.get_ref()
@@ -618,7 +620,9 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     pub fn get_mut(&mut self) -> &mut S {
         self.0.get_mut()
     }
+}
 
+impl<S: io::Read + io::Write> TlsStream<S> {
     /// Returns the number of bytes that can be read without resulting in any
     /// network calls.
     pub fn buffered_read_size(&self) -> Result<usize> {


### PR DESCRIPTION
It should not be necessary to have `S: Read + Write` to get at references to `S` through `TlsStream<S>`, so this patch removes those bounds. This matters little in practice, since you likely can't construct a `TlsStream` on an `S` that isn't `Read + Write`, but it does mean that downstream crates that wrap `TlsStream` do not have to repeat the `Read + Write` bounds for _their_ `get_` methods.