### PR TITLE
Impl/error source

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -133,6 +133,13 @@ impl error::Error for Error {
             Error::Ssl(ref e, _) => error::Error::cause(e),
         }
     }
+
+    fn source(&self) -> Option<&error::Error + 'static> {
+        match *self {
+            Error::Normal(ref e) => Some(e),
+            Error::Ssl(ref e, _) => Some(e),
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -127,14 +127,14 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Normal(ref e) => error::Error::cause(e),
             Error::Ssl(ref e, _) => error::Error::cause(e),
         }
     }
 
-    fn source(&self) -> Option<&error::Error + 'static> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::Normal(ref e) => Some(e),
             Error::Ssl(ref e, _) => Some(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,11 +136,11 @@ impl error::Error for Error {
         error::Error::description(&self.0)
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         error::Error::cause(&self.0)
     }
 
-    fn source(&self) -> Option<&error::Error + 'static> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         error::Error::source(&self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,10 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         error::Error::cause(&self.0)
     }
+
+    fn source(&self) -> Option<&error::Error + 'static> {
+        error::Error::source(&self.0)
+    }
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
I added `source` method of `std::error::Error` for `Error` and `imp::openssl::Error`.
This PR enable users `downcast_ref` errors like:

```
let tls_error: native_tls::Error = ...
if let Some(ref ssl_error) =tls_error
    .source()
    .and_then(|e| e.downcast_ref::<openssl::ssl::Error>())
{
    ...
}
```

