### PR TITLE
Identity from PEMs

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -168,6 +168,16 @@ impl Identity {
             chain: parsed.chain.into_iter().flat_map(|x| x).collect(),
         })
     }
+
+    pub fn from_pems(pkey_buf: &[u8], cert_buf: &[u8], chain_buf: Vec<&[u8]>) -> Result<Identity, Error> {        
+        let pkey = PKey::private_key_from_pem(pkey_buf)?;
+        let cert = X509::from_pem(cert_buf)?;
+        Ok(Identity {
+            pkey,
+            cert,
+            chain: chain_buf.into_iter().map(|b| X509::from_pem(b).unwrap()).collect(),
+        })
+    }
 }
 
 #[derive(Clone)]

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -14,7 +14,7 @@ use self::openssl::x509::{X509, X509VerifyResult};
 use std::error;
 use std::fmt;
 use std::io;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::{Once};
 
 use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
 use self::openssl::pkey::Private;
@@ -90,7 +90,7 @@ fn supported_protocols(
 }
 
 fn init_trust() {
-    static ONCE: Once = ONCE_INIT;
+    static ONCE: Once = Once::new();
     ONCE.call_once(|| openssl_probe::init_ssl_cert_env_vars());
 }
 
@@ -127,10 +127,10 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            Error::Normal(ref e) => error::Error::cause(e),
-            Error::Ssl(ref e, _) => error::Error::cause(e),
+            Error::Normal(ref e) => error::Error::source(e),
+            Error::Ssl(ref e, _) => error::Error::source(e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,8 @@ impl error::Error for Error {
         error::Error::description(&self.0)
     }
 
-    fn cause(&self) -> Option<&error::Error> {
-        error::Error::cause(&self.0)
+    fn cause(&self) -> Option<&dyn error::Error> {
+        error::Error::source(&self.0)
     }
 }
 
@@ -287,7 +287,7 @@ where
         "handshake error"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             HandshakeError::Failure(ref e) => Some(e),
             HandshakeError::WouldBlock(_) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,18 @@ impl Identity {
         let identity = imp::Identity::from_pkcs12(der, password)?;
         Ok(Identity(identity))
     }
+
+    /// Create an idenity from three individual PEM files
+    /// 
+    /// This is a setup as provided by 'LetsEncrypt' including the following files 
+    /// - cert.pem 
+    /// - fullchain.pem 
+    /// - privkey.pem 
+    /// 
+    pub fn from_pems(pkey: &[u8], cert: &[u8], chain: Vec<&[u8]>) -> Result<Identity> {
+        let identity = imp::Identity::from_pems(pkey, cert, chain)?;
+        Ok(Identity(identity))
+    }
 }
 
 /// An X509 certificate.


### PR DESCRIPTION
This adds a convenience method to create an Identity from PEMs, which are provided by LetsEncrypt. 
Furthermore resolves some deprecated warnings.  