### PR TITLE
Implement bindings to only use supplied root certificates for validating the server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ schannel = "0.1.16"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.25"
-openssl-sys = "0.9.30"
+openssl = "0.10.29"
+openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 
 [dev-dependencies]

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -10,7 +10,7 @@ use self::openssl::ssl::{
     self, MidHandshakeSslStream, SslAcceptor, SslConnector, SslContextBuilder, SslMethod,
     SslVerifyMode,
 };
-use self::openssl::x509::{X509, X509VerifyResult};
+use self::openssl::x509::{X509, store::X509StoreBuilder, X509VerifyResult};
 use std::error;
 use std::fmt;
 use std::io;
@@ -263,6 +263,10 @@ impl TlsConnector {
             }
         }
         supported_protocols(builder.min_protocol, builder.max_protocol, &mut connector)?;
+
+        if builder.disable_built_in_roots {
+            connector.set_cert_store(X509StoreBuilder::new()?.build());
+        }
 
         for cert in &builder.root_certificates {
             if let Err(err) = connector.cert_store_mut().add_cert((cert.0).0.clone()) {

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -262,6 +262,7 @@ pub struct TlsConnector {
     use_sni: bool,
     danger_accept_invalid_hostnames: bool,
     danger_accept_invalid_certs: bool,
+    disable_built_in_roots: bool,
 }
 
 impl TlsConnector {
@@ -278,6 +279,7 @@ impl TlsConnector {
             use_sni: builder.use_sni,
             danger_accept_invalid_hostnames: builder.accept_invalid_hostnames,
             danger_accept_invalid_certs: builder.accept_invalid_certs,
+            disable_built_in_roots: builder.disable_built_in_roots,
         })
     }
 
@@ -299,6 +301,7 @@ impl TlsConnector {
         builder.use_sni(self.use_sni);
         builder.danger_accept_invalid_hostnames(self.danger_accept_invalid_hostnames);
         builder.danger_accept_invalid_certs(self.danger_accept_invalid_certs);
+        builder.trust_anchor_certificates_only(self.disable_built_in_roots);
 
         match builder.handshake(domain, stream) {
             Ok(stream) => Ok(TlsStream { stream, cert: None }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,7 @@ pub struct TlsConnectorBuilder {
     accept_invalid_certs: bool,
     accept_invalid_hostnames: bool,
     use_sni: bool,
+    disable_built_in_roots: bool,
 }
 
 impl TlsConnectorBuilder {
@@ -364,6 +365,14 @@ impl TlsConnectorBuilder {
     /// Defaults to an empty set.
     pub fn add_root_certificate(&mut self, cert: Certificate) -> &mut TlsConnectorBuilder {
         self.root_certificates.push(cert);
+        self
+    }
+
+    /// Controls the use of built-in system certificates during certificate validation.
+    ///
+    /// Defaults to `false` -- built-in system certs will be used.
+    pub fn disable_built_in_roots(&mut self, disable: bool) -> &mut TlsConnectorBuilder {
+        self.disable_built_in_roots = disable;
         self
     }
 
@@ -454,6 +463,7 @@ impl TlsConnector {
             use_sni: true,
             accept_invalid_certs: false,
             accept_invalid_hostnames: false,
+            disable_built_in_roots: false,
         }
     }
 


### PR DESCRIPTION
Implements a way to distrust the system cert store on all backends.

  - On macOS, this just uses `trust_anchor_certificates_only`.
  - On Windows, this uses a custom `verify_callback` that manually checks that the root cert exists in the user-specified root certs.
  - On OpenSSL, this manually creates a new `X509Store` with the user-specified root certs and sets it with `set_verify_cert_store`. This is the one I'm least sure about -- it is probably more correct to avoid calling `set_default_verify_paths`, but that currently happens on builder construction, and moving where that happens might be a breaking change (as `set_default_verify_paths` reads environment variables, which are set process-wide).

Closes #41.