### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -91,7 +91,7 @@ fn supported_protocols(
 
 fn init_trust() {
     static ONCE: Once = Once::new();
-    ONCE.call_once(|| openssl_probe::init_ssl_cert_env_vars());
+    ONCE.call_once(openssl_probe::init_ssl_cert_env_vars);
 }
 
 #[cfg(target_os = "android")]
@@ -158,7 +158,7 @@ impl Identity {
         Ok(Identity {
             pkey: parsed.pkey,
             cert: parsed.cert,
-            chain: parsed.chain.into_iter().flat_map(|x| x).collect(),
+            chain: parsed.chain.into_iter().flatten().collect(),
         })
     }
 }


### PR DESCRIPTION
It's possible use `flatten` instead `flat_map` from rust 1.29 -- https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.flatten