### PR TITLE
Implement ALPN support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       version:
         type: string
     macos:
-      xcode: "9.0"
+      xcode: "10.0.0"
     environment:
       RUST_BACKTRACE: 1
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "0.4.1"
-security-framework-sys = "0.4.1"
+security-framework = { version = "0.4.4", features = ["alpn"] }
+security-framework-sys = "0.4.3"
 lazy_static = "1.0"
 libc = "0.2"
 tempfile = "3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,7 @@ pub struct TlsConnectorBuilder {
     accept_invalid_hostnames: bool,
     use_sni: bool,
     disable_built_in_roots: bool,
+    alpn: Vec<Vec<u8>>,
 }
 
 impl TlsConnectorBuilder {
@@ -373,6 +374,14 @@ impl TlsConnectorBuilder {
     /// Defaults to `false` -- built-in system certs will be used.
     pub fn disable_built_in_roots(&mut self, disable: bool) -> &mut TlsConnectorBuilder {
         self.disable_built_in_roots = disable;
+        self
+    }
+
+    /// Request specific protocols through ALPN (Application-Layer Protocol Negotiation).
+    ///
+    /// Defaults to none
+    pub fn request_alpns(&mut self, protocols: &[&[u8]]) -> &mut TlsConnectorBuilder {
+        self.alpn = protocols.iter().map(|s| s.to_vec()).collect();
         self
     }
 
@@ -464,6 +473,7 @@ impl TlsConnector {
             accept_invalid_certs: false,
             accept_invalid_hostnames: false,
             disable_built_in_roots: false,
+            alpn: vec![],
         }
     }
 
@@ -642,6 +652,11 @@ impl<S: io::Read + io::Write> TlsStream<S> {
     /// [RFC 5929]: https://tools.ietf.org/html/rfc5929
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>> {
         Ok(self.0.tls_server_end_point()?)
+    }
+
+    /// Returns the negotiated ALPN protocols
+    pub fn negotiated_alpn(&self) -> Result<Option<Vec<u8>>> {
+        Ok(self.0.negotiated_alpn()?)
     }
 
     /// Shuts down the TLS session.

--- a/src/test.rs
+++ b/src/test.rs
@@ -417,4 +417,31 @@ mod tests {
 
         p!(j.join());
     }
+
+    #[test]
+    fn alpn_google_h2() {
+        let builder = p!(TlsConnector::builder().request_alpns(&[b"h2"]).build());
+        let s = p!(TcpStream::connect("google.com:443"));
+        let socket = p!(builder.connect("google.com", s));
+
+        assert_eq!(p!(socket.negotiated_alpn()), Some(b"h2".to_vec()));
+    }
+
+    #[test]
+    fn alpn_google_invalid() {
+        let builder = p!(TlsConnector::builder().request_alpns(&[b"h2c"]).build());
+        let s = p!(TcpStream::connect("google.com:443"));
+        let socket = p!(builder.connect("google.com", s));
+
+        assert_eq!(p!(socket.negotiated_alpn()), None);
+    }
+
+    #[test]
+    fn alpn_google_none() {
+        let builder = p!(TlsConnector::new());
+        let s = p!(TcpStream::connect("google.com:443"));
+        let socket = p!(builder.connect("google.com", s));
+
+        assert_eq!(p!(socket.negotiated_alpn()), None);
+    }
 }


### PR DESCRIPTION
An alternative to #157 .

Slightly more surgical in a lot of places, doesn't require an extra feature, correct error handling on macOS, and some simple tests.

Closes #49.