### PR TITLE
Support cipher suite selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 tempfile = "3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.16"
+schannel = "0.1.19"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -2,14 +2,86 @@ extern crate schannel;
 
 use self::schannel::cert_context::{CertContext, HashAlgorithm};
 use self::schannel::cert_store::{CertAdd, CertStore, Memory, PfxImportOptions};
-use self::schannel::schannel_cred::{Direction, Protocol, SchannelCred};
+use self::schannel::schannel_cred::{Algorithm, Direction, Protocol, SchannelCred};
 use self::schannel::tls_stream;
 use std::error;
 use std::fmt;
 use std::io;
 use std::str;
 
-use {TlsAcceptorBuilder, TlsConnectorBuilder};
+use {
+    CipherSuiteSet, TlsAcceptorBuilder, TlsBulkEncryptionAlgorithm, TlsConnectorBuilder,
+    TlsHashAlgorithm, TlsKeyExchangeAlgorithm, TlsSignatureAlgorithm,
+};
+
+impl From<TlsKeyExchangeAlgorithm> for Algorithm {
+    fn from(other: TlsKeyExchangeAlgorithm) -> Self {
+        match other {
+            TlsKeyExchangeAlgorithm::Dhe => Algorithm::DhEphem,
+            TlsKeyExchangeAlgorithm::Ecdhe => Algorithm::EcdhEphem,
+            TlsKeyExchangeAlgorithm::Rsa => Algorithm::RsaKeyx,
+            TlsKeyExchangeAlgorithm::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+impl From<TlsSignatureAlgorithm> for Algorithm {
+    fn from(other: TlsSignatureAlgorithm) -> Self {
+        match other {
+            TlsSignatureAlgorithm::Dss => Algorithm::DssSign,
+            TlsSignatureAlgorithm::Ecdsa => Algorithm::Ecdsa,
+            TlsSignatureAlgorithm::Rsa => Algorithm::RsaSign,
+            TlsSignatureAlgorithm::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+impl From<TlsBulkEncryptionAlgorithm> for Algorithm {
+    fn from(other: TlsBulkEncryptionAlgorithm) -> Self {
+        match other {
+            TlsBulkEncryptionAlgorithm::Aes128 => Algorithm::Aes128,
+            TlsBulkEncryptionAlgorithm::Aes256 => Algorithm::Aes256,
+            TlsBulkEncryptionAlgorithm::Des => Algorithm::Des,
+            TlsBulkEncryptionAlgorithm::Rc2 => Algorithm::Rc2,
+            TlsBulkEncryptionAlgorithm::Rc4 => Algorithm::Rc4,
+            TlsBulkEncryptionAlgorithm::TripleDes => Algorithm::TripleDes,
+            TlsBulkEncryptionAlgorithm::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+impl From<TlsHashAlgorithm> for Algorithm {
+    fn from(other: TlsHashAlgorithm) -> Self {
+        match other {
+            TlsHashAlgorithm::Md5 => Algorithm::Md5,
+            TlsHashAlgorithm::Sha1 => Algorithm::Sha1,
+            TlsHashAlgorithm::Sha256 => Algorithm::Sha256,
+            TlsHashAlgorithm::Sha384 => Algorithm::Sha384,
+            TlsHashAlgorithm::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+fn expand_algorithms(cipher_suites: &CipherSuiteSet) -> Vec<Algorithm> {
+    let mut ret = vec![];
+    ret.extend(
+        cipher_suites
+            .key_exchange
+            .iter()
+            .copied()
+            .map(Algorithm::from),
+    );
+    ret.extend(cipher_suites.signature.iter().copied().map(Algorithm::from));
+    ret.extend(
+        cipher_suites
+            .bulk_encryption
+            .iter()
+            .copied()
+            .map(Algorithm::from),
+    );
+    ret.extend(cipher_suites.hash.iter().copied().map(Algorithm::from));
+    ret
+}
 
 const SEC_E_NO_CREDENTIALS: u32 = 0x8009030E;
 
@@ -186,6 +258,7 @@ pub struct TlsConnector {
     accept_invalid_hostnames: bool,
     accept_invalid_certs: bool,
     disable_built_in_roots: bool,
+    supported_algorithms: Vec<Algorithm>,
 }
 
 impl TlsConnector {
@@ -205,6 +278,10 @@ impl TlsConnector {
             accept_invalid_hostnames: builder.accept_invalid_hostnames,
             accept_invalid_certs: builder.accept_invalid_certs,
             disable_built_in_roots: builder.disable_built_in_roots,
+            supported_algorithms: match &builder.cipher_suites {
+                Some(cipher_suites) => expand_algorithms(cipher_suites),
+                None => vec![],
+            },
         })
     }
 
@@ -216,6 +293,9 @@ impl TlsConnector {
         builder.enabled_protocols(convert_protocols(self.min_protocol, self.max_protocol));
         if let Some(cert) = self.cert.as_ref() {
             builder.cert(cert.clone());
+        }
+        if !self.supported_algorithms.is_empty() {
+            builder.supported_algorithms(&self.supported_algorithms);
         }
         let cred = builder.acquire(Direction::Outbound)?;
         let mut builder = tls_stream::Builder::new();

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -5,6 +5,7 @@ extern crate tempfile;
 
 use self::security_framework::base;
 use self::security_framework::certificate::SecCertificate;
+use self::security_framework::cipher_suite::CipherSuite;
 use self::security_framework::identity::SecIdentity;
 use self::security_framework::import_export::{ImportedIdentity, Pkcs12ImportOptions};
 use self::security_framework::secure_transport::{
@@ -12,6 +13,7 @@ use self::security_framework::secure_transport::{
 };
 use self::security_framework_sys::base::errSecIO;
 use self::tempfile::TempDir;
+use std::collections::HashSet;
 use std::error;
 use std::fmt;
 use std::io;
@@ -29,13 +31,495 @@ use self::security_framework::os::macos::keychain::{self, KeychainSettings, SecK
 #[cfg(not(target_os = "ios"))]
 use self::security_framework_sys::base::errSecParam;
 
-use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
+use {
+    CipherSuiteSet, Protocol, TlsAcceptorBuilder, TlsBulkEncryptionAlgorithm, TlsConnectorBuilder,
+    TlsHashAlgorithm, TlsKeyExchangeAlgorithm, TlsSignatureAlgorithm,
+};
 
 static SET_AT_EXIT: Once = Once::new();
 
 #[cfg(not(target_os = "ios"))]
 lazy_static! {
     static ref TEMP_KEYCHAIN: Mutex<Option<(SecKeychain, TempDir)>> = Mutex::new(None);
+}
+
+const CIPHERS_3DES: &[CipherSuite] = &[
+    CipherSuite::TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::SSL_RSA_WITH_3DES_EDE_CBC_MD5,
+];
+
+const CIPHERS_AES_128: &[CipherSuite] = &[
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_PSK_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+];
+
+const CIPHERS_AES_256: &[CipherSuite] = &[
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+    // CipherSuite::TLS_PSK_WITH_AES_256_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_PSK_WITH_AES_256_CBC_SHA384,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_CBC_SHA384,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+];
+
+const CIPHERS_DES: &[CipherSuite] = &[
+    CipherSuite::SSL_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DH_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DH_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_MD5,
+];
+
+const CIPHERS_DH_EPHEM: &[CipherSuite] = &[
+    CipherSuite::SSL_DHE_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_CBC_SHA384,
+];
+
+const CIPHERS_DSS: &[CipherSuite] = &[
+    CipherSuite::SSL_DH_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_GCM_SHA384,
+];
+
+const CIPHERS_ECDHE: &[CipherSuite] = &[
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+];
+
+const CIPHERS_ECDSA: &[CipherSuite] = &[
+    CipherSuite::TLS_ECDH_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+];
+
+const CIPHERS_MD5: &[CipherSuite] = &[
+    CipherSuite::SSL_RSA_WITH_RC4_128_MD5,
+    CipherSuite::TLS_RSA_WITH_RC4_128_MD5,
+    CipherSuite::SSL_RSA_WITH_RC2_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_IDEA_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_3DES_EDE_CBC_MD5,
+];
+
+const CIPHERS_RC2: &[CipherSuite] = &[CipherSuite::SSL_RSA_WITH_RC2_CBC_MD5];
+
+const CIPHERS_RC4: &[CipherSuite] = &[
+    CipherSuite::SSL_RSA_WITH_RC4_128_MD5,
+    CipherSuite::SSL_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_RSA_WITH_RC4_128_MD5,
+    CipherSuite::TLS_RSA_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_RC4_128_SHA,
+];
+
+const CIPHERS_RSA_KEYX: &[CipherSuite] = &[
+    CipherSuite::SSL_RSA_WITH_RC4_128_MD5,
+    CipherSuite::SSL_RSA_WITH_RC4_128_SHA,
+    CipherSuite::SSL_RSA_WITH_IDEA_CBC_SHA,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_RC4_128_MD5,
+    CipherSuite::TLS_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::SSL_RSA_WITH_RC2_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_IDEA_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_3DES_EDE_CBC_MD5,
+];
+
+const CIPHERS_RSA_SIGN: &[CipherSuite] = &[
+    CipherSuite::SSL_RSA_WITH_RC4_128_MD5,
+    CipherSuite::SSL_RSA_WITH_RC4_128_SHA,
+    CipherSuite::SSL_RSA_WITH_IDEA_CBC_SHA,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DH_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_RC4_128_MD5,
+    CipherSuite::TLS_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::SSL_RSA_WITH_RC2_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_IDEA_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_MD5,
+    CipherSuite::SSL_RSA_WITH_3DES_EDE_CBC_MD5,
+];
+
+const CIPHERS_SHA1: &[CipherSuite] = &[
+    CipherSuite::SSL_RSA_WITH_RC4_128_SHA,
+    CipherSuite::SSL_RSA_WITH_IDEA_CBC_SHA,
+    CipherSuite::SSL_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DH_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DH_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_DSS_WITH_DES_CBC_SHA,
+    CipherSuite::SSL_DHE_RSA_WITH_DES_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+    CipherSuite::TLS_RSA_WITH_RC4_128_SHA,
+    CipherSuite::TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA,
+    CipherSuite::TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_PSK_WITH_AES_256_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_RC4_128_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA,
+];
+
+const CIPHERS_SHA256: &[CipherSuite] = &[
+    CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+    CipherSuite::TLS_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_DSS_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_DH_anon_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_GCM_SHA256,
+    // CipherSuite::TLS_PSK_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_128_CBC_SHA256,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+];
+
+const CIPHERS_SHA384: &[CipherSuite] = &[
+    CipherSuite::TLS_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DH_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_DH_DSS_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_GCM_SHA384,
+    // CipherSuite::TLS_PSK_WITH_AES_256_CBC_SHA384,
+    // CipherSuite::TLS_DHE_PSK_WITH_AES_256_CBC_SHA384,
+    // CipherSuite::TLS_RSA_PSK_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    CipherSuite::TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+];
+
+fn key_exchange_alg_to_cipher_suites(alg: &TlsKeyExchangeAlgorithm) -> &'static [CipherSuite] {
+    match alg {
+        TlsKeyExchangeAlgorithm::Dhe => CIPHERS_DH_EPHEM,
+        TlsKeyExchangeAlgorithm::Ecdhe => CIPHERS_ECDHE,
+        TlsKeyExchangeAlgorithm::Rsa => CIPHERS_RSA_KEYX,
+        TlsKeyExchangeAlgorithm::__NonExhaustive => unreachable!(),
+    }
+}
+
+fn signature_alg_to_cipher_suites(alg: &TlsSignatureAlgorithm) -> &'static [CipherSuite] {
+    match alg {
+        TlsSignatureAlgorithm::Dss => CIPHERS_DSS,
+        TlsSignatureAlgorithm::Ecdsa => CIPHERS_ECDSA,
+        TlsSignatureAlgorithm::Rsa => CIPHERS_RSA_SIGN,
+        TlsSignatureAlgorithm::__NonExhaustive => unreachable!(),
+    }
+}
+
+fn bulk_encryption_alg_to_cipher_suites(
+    alg: &TlsBulkEncryptionAlgorithm,
+) -> &'static [CipherSuite] {
+    match alg {
+        TlsBulkEncryptionAlgorithm::Aes128 => CIPHERS_AES_128,
+        TlsBulkEncryptionAlgorithm::Aes256 => CIPHERS_AES_256,
+        TlsBulkEncryptionAlgorithm::Des => CIPHERS_DES,
+        TlsBulkEncryptionAlgorithm::Rc2 => CIPHERS_RC2,
+        TlsBulkEncryptionAlgorithm::Rc4 => CIPHERS_RC4,
+        TlsBulkEncryptionAlgorithm::TripleDes => CIPHERS_3DES,
+        TlsBulkEncryptionAlgorithm::__NonExhaustive => unreachable!(),
+    }
+}
+
+fn hash_alg_to_cipher_suites(alg: &TlsHashAlgorithm) -> &'static [CipherSuite] {
+    match alg {
+        TlsHashAlgorithm::Md5 => CIPHERS_MD5,
+        TlsHashAlgorithm::Sha1 => CIPHERS_SHA1,
+        TlsHashAlgorithm::Sha256 => CIPHERS_SHA256,
+        TlsHashAlgorithm::Sha384 => CIPHERS_SHA384,
+        TlsHashAlgorithm::__NonExhaustive => unreachable!(),
+    }
+}
+
+fn expand_algorithms(cipher_suites: &CipherSuiteSet) -> Vec<CipherSuite> {
+    let first = cipher_suites
+        .key_exchange
+        .iter()
+        .flat_map(key_exchange_alg_to_cipher_suites)
+        .copied();
+    let rest: &[HashSet<_>] = &[
+        cipher_suites
+            .signature
+            .iter()
+            .flat_map(signature_alg_to_cipher_suites)
+            .copied()
+            .collect(),
+        cipher_suites
+            .bulk_encryption
+            .iter()
+            .flat_map(bulk_encryption_alg_to_cipher_suites)
+            .copied()
+            .collect(),
+        cipher_suites
+            .hash
+            .iter()
+            .flat_map(hash_alg_to_cipher_suites)
+            .copied()
+            .collect(),
+    ];
+
+    first
+        .filter(|alg| rest.iter().all(|algs| algs.contains(alg)))
+        .collect()
 }
 
 fn convert_protocol(protocol: Protocol) -> SslProtocol {
@@ -263,6 +747,7 @@ pub struct TlsConnector {
     danger_accept_invalid_hostnames: bool,
     danger_accept_invalid_certs: bool,
     disable_built_in_roots: bool,
+    cipher_suites: Vec<CipherSuite>,
 }
 
 impl TlsConnector {
@@ -280,6 +765,10 @@ impl TlsConnector {
             danger_accept_invalid_hostnames: builder.accept_invalid_hostnames,
             danger_accept_invalid_certs: builder.accept_invalid_certs,
             disable_built_in_roots: builder.disable_built_in_roots,
+            cipher_suites: match &builder.cipher_suites {
+                Some(cipher_suites) => expand_algorithms(&cipher_suites),
+                None => vec![],
+            },
         })
     }
 
@@ -302,6 +791,9 @@ impl TlsConnector {
         builder.danger_accept_invalid_hostnames(self.danger_accept_invalid_hostnames);
         builder.danger_accept_invalid_certs(self.danger_accept_invalid_certs);
         builder.trust_anchor_certificates_only(self.disable_built_in_roots);
+        if !self.cipher_suites.is_empty() {
+            builder.whitelist_ciphers(&self.cipher_suites);
+        }
 
         match builder.handshake(domain, stream) {
             Ok(stream) => Ok(TlsStream { stream, cert: None }),
@@ -538,4 +1030,38 @@ extern "C" {
     fn CC_SHA256(data: *const u8, len: CC_LONG, md: *mut u8) -> *mut u8;
     fn CC_SHA384(data: *const u8, len: CC_LONG, md: *mut u8) -> *mut u8;
     fn CC_SHA512(data: *const u8, len: CC_LONG, md: *mut u8) -> *mut u8;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_algorithms_basic() {
+        assert_eq!(
+            expand_algorithms(&CipherSuiteSet {
+                key_exchange: vec![TlsKeyExchangeAlgorithm::Dhe, TlsKeyExchangeAlgorithm::Ecdhe],
+                signature: vec![TlsSignatureAlgorithm::Rsa],
+                bulk_encryption: vec![
+                    TlsBulkEncryptionAlgorithm::Aes128,
+                    TlsBulkEncryptionAlgorithm::Aes256,
+                ],
+                hash: vec![TlsHashAlgorithm::Sha256, TlsHashAlgorithm::Sha384],
+            })
+            .into_iter()
+            .collect::<HashSet<_>>(),
+            vec![
+                CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+                CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+                CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+                CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+                CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+                CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+                CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            ]
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,137 @@ pub enum Protocol {
     __NonExhaustive,
 }
 
+/// TLS cipher suite key-exchange algorithms.
+#[derive(Debug, Copy, Clone)]
+pub enum TlsKeyExchangeAlgorithm {
+    /// Diffie-Hellman ephemeral key exchange algorithm.
+    Dhe,
+    /// Ephemeral elliptic curve Diffie-Hellman key exchange algorithm.
+    Ecdhe,
+    /// RSA public key exchange algorithm.
+    Rsa,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+/// TLS cipher suite message signature algorithms.
+#[derive(Debug, Copy, Clone)]
+pub enum TlsSignatureAlgorithm {
+    /// DSA public key signature algorithm.
+    Dss,
+    /// Elliptic curve digital signature algorithm.
+    Ecdsa,
+    /// RSA public key signature algorithm.
+    Rsa,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+/// TLS cipher suite bulk encryption algorithms.
+#[derive(Debug, Copy, Clone)]
+pub enum TlsBulkEncryptionAlgorithm {
+    /// 128 bit AES.
+    Aes128,
+    /// 256 bit AES.
+    Aes256,
+    /// DES encryption algorithm.
+    Des,
+    /// RC2 block encryption algorithm.
+    Rc2,
+    /// RC4 stream encryption algorithm.
+    Rc4,
+    /// Triple DES encryption algorithm.
+    TripleDes,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+/// TLS cipher suite bulk encryption algorithms.
+#[derive(Debug, Copy, Clone)]
+pub enum TlsHashAlgorithm {
+    /// MD5 hashing algorithm.
+    Md5,
+    /// SHA hashing algorithm.
+    Sha1,
+    /// 256 bit SHA hashing algorithm.
+    Sha256,
+    /// 384 bit SHA hashing algorithm.
+    Sha384,
+    // TODO: Not supported by macOS Security Framework.
+    // /// 512 bit SHA hashing algorithm.
+    // Sha512,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+/// Represents a collection of cipher suites, specified by a cartesian product of their separate
+/// algorithm components.
+///
+/// Note that the `Default` here is consistent across platforms and is not equivalent to the
+/// platform-specific defaults on each individual platform. [`CipherSuiteSet::default`] corresponds
+/// to DHE, ECDHE, and RSA for key exchange, ECDSA and RSA for signature, AES-128 and AES-256 for
+/// bulk encryption, and SHA1, SHA256, and SHA384 for hashing.
+#[derive(Debug, Clone)]
+pub struct CipherSuiteSet {
+    key_exchange: Vec<TlsKeyExchangeAlgorithm>,
+    signature: Vec<TlsSignatureAlgorithm>,
+    bulk_encryption: Vec<TlsBulkEncryptionAlgorithm>,
+    hash: Vec<TlsHashAlgorithm>,
+}
+
+impl Default for CipherSuiteSet {
+    fn default() -> Self {
+        // Based on the default TLS cipher suites in rust-openssl.
+        Self {
+            key_exchange: vec![
+                TlsKeyExchangeAlgorithm::Dhe,
+                TlsKeyExchangeAlgorithm::Ecdhe,
+                TlsKeyExchangeAlgorithm::Rsa,
+            ],
+            signature: vec![TlsSignatureAlgorithm::Ecdsa, TlsSignatureAlgorithm::Rsa],
+            bulk_encryption: vec![
+                TlsBulkEncryptionAlgorithm::Aes128,
+                TlsBulkEncryptionAlgorithm::Aes256,
+            ],
+            hash: vec![
+                TlsHashAlgorithm::Sha1,
+                TlsHashAlgorithm::Sha256,
+                TlsHashAlgorithm::Sha384,
+            ],
+        }
+    }
+}
+
+impl CipherSuiteSet {
+    /// Allow only ciphersuites with the specified key exchange algorithms.
+    pub fn key_exchange_algorithms(mut self, algs: &[TlsKeyExchangeAlgorithm]) -> Self {
+        assert!(!algs.is_empty(), "cannot specify 0 algorithms");
+        self.key_exchange = algs.to_vec();
+        self
+    }
+
+    /// Allow only ciphersuites with the specified signature algorithms.
+    pub fn signature_algorithms(mut self, algs: &[TlsSignatureAlgorithm]) -> Self {
+        assert!(!algs.is_empty(), "cannot specify 0 algorithms");
+        self.signature = algs.to_vec();
+        self
+    }
+
+    /// Allow only ciphersuites with the specified bulk encryption algorithms.
+    pub fn bulk_encryption_algorithms(mut self, algs: &[TlsBulkEncryptionAlgorithm]) -> Self {
+        assert!(!algs.is_empty(), "cannot specify 0 algorithms");
+        self.bulk_encryption = algs.to_vec();
+        self
+    }
+
+    /// Allow only ciphersuites with the specified hash algorithms.
+    pub fn hash_algorithms(mut self, algs: &[TlsHashAlgorithm]) -> Self {
+        assert!(!algs.is_empty(), "cannot specify 0 algorithms");
+        self.hash = algs.to_vec();
+        self
+    }
+}
+
 /// A builder for `TlsConnector`s.
 pub struct TlsConnectorBuilder {
     identity: Option<Identity>,
@@ -328,6 +459,7 @@ pub struct TlsConnectorBuilder {
     accept_invalid_hostnames: bool,
     use_sni: bool,
     disable_built_in_roots: bool,
+    cipher_suites: Option<CipherSuiteSet>,
 }
 
 impl TlsConnectorBuilder {
@@ -418,6 +550,15 @@ impl TlsConnectorBuilder {
         self
     }
 
+    /// Sets the set of cipher suites that will be used in this TLS connection.
+    pub fn supported_cipher_suites(
+        &mut self,
+        cipher_suites: CipherSuiteSet,
+    ) -> &mut TlsConnectorBuilder {
+        self.cipher_suites = Some(cipher_suites);
+        self
+    }
+
     /// Creates a new `TlsConnector`.
     pub fn build(&self) -> Result<TlsConnector> {
         let connector = imp::TlsConnector::new(self)?;
@@ -464,6 +605,7 @@ impl TlsConnector {
             accept_invalid_certs: false,
             accept_invalid_hostnames: false,
             disable_built_in_roots: false,
+            cipher_suites: None,
         }
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -417,4 +417,28 @@ mod tests {
 
         p!(j.join());
     }
+
+    #[test]
+    fn badssl_cipher_suites_no_rsa() {
+        let builder = p!(TlsConnector::builder().supported_cipher_suites(
+            // Oddly, on Windows, allowing RSA key exchange, but not RSA signature algorithms still
+            // allows a successful TLS connection, despite there being no non-RSA signature cipher
+            // suites in the Mozilla Intermediate set AFAICT. Removing RSA from the key exchange
+            // algorithms causes this test to work as expected.
+            CipherSuiteSet::default()
+                .key_exchange_algorithms(&[TlsKeyExchangeAlgorithm::Ecdhe])
+                .signature_algorithms(&[TlsSignatureAlgorithm::Ecdsa])
+        ).build());
+        let s = p!(TcpStream::connect("mozilla-intermediate.badssl.com:443"));
+        assert!(builder.connect("mozilla-intermediate.badssl.com", s).is_err());
+    }
+
+    #[test]
+    fn badssl_cipher_suites_default() {
+        let builder = p!(TlsConnector::builder().supported_cipher_suites(
+            CipherSuiteSet::default()
+        ).build());
+        let s = p!(TcpStream::connect("mozilla-intermediate.badssl.com:443"));
+        p!(builder.connect("mozilla-intermediate.badssl.com", s));
+    }
 }


### PR DESCRIPTION
The exported API is implemented as an explicit whitelist with a consistent default across platforms based on the allowed ciphersuites in rust-openssl, which is itself based on the list from Python.

The implementation for each backend is roughly what you'd expect.
  - For OpenSSL, it constructs a cartesian product of the selected algorithms, joined together with `+`.
  - For Schannel, it just maps the chosen algorithms to the correct Schannel equivalent.
  - For the Security Framework, it doesn't look like there's any structure behind the ciphersuite constants or more user-friendly APIs for interacting with them, so I've combed through the ciphersuite list and manually compiled lists of cipher suites that use each algorithm.

SHA512 is not included as a possible hash algorithm because it appears to be only available in the Security Framework.

Closes #4.