### PR TITLE
Add force_ssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,23 +8,31 @@ repository = "https://github.com/sfackler/rust-native-tls"
 readme = "README.md"
 
 [features]
+default = ["security-framework", "security-framework-sys", "lazy_static", "libc", "tempfile", "schannel"]
 vendored = ["openssl/vendored"]
+force_ssl = ["log", "openssl", "openssl-sys", "openssl-probe"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "0.4.1"
-security-framework-sys = "0.4.1"
-lazy_static = "1.0"
-libc = "0.2"
-tempfile = "3.0"
+security-framework = { version = "0.4.1", optional = true }
+security-framework-sys = { version = "0.4.1", optional = true }
+lazy_static = { version = "1.0", optional = true }
+libc = { version = "0.2", optional = true }
+tempfile = { version = "3.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.16"
+schannel = { version = "0.1.16", optional = true }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"
 openssl = "0.10.29"
 openssl-sys = "0.9.55"
 openssl-probe = "0.1"
+
+[dependencies]
+log = { version = "0.4.5", optional = true }
+openssl = { version = "0.10.29", optional = true }
+openssl-sys = { version = "0.9.55", optional = true }
+openssl-probe = { version = "0.1", optional = true }
 
 [dev-dependencies]
 hex = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 #![warn(missing_docs)]
 
 #[macro_use]
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(all(not(feature = "force_ssl"), any(target_os = "macos", target_os = "ios")))]
 extern crate lazy_static;
 
 #[cfg(test)]
@@ -109,16 +109,16 @@ use std::fmt;
 use std::io;
 use std::result;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(any(feature = "force_ssl", not(any(target_os = "macos", target_os = "windows", target_os = "ios"))))]
 #[macro_use]
 extern crate log;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(all(not(feature = "force_ssl"), any(target_os = "macos", target_os = "ios")))]
 #[path = "imp/security_framework.rs"]
 mod imp;
-#[cfg(target_os = "windows")]
+#[cfg(all(not(feature = "force_ssl"), target_os = "windows"))]
 #[path = "imp/schannel.rs"]
 mod imp;
-#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+#[cfg(any(feature = "force_ssl", not(any(target_os = "macos", target_os = "windows", target_os = "ios"))))]
 #[path = "imp/openssl.rs"]
 mod imp;
 


### PR DESCRIPTION
When this feature is selected, attempt to use openssl even on Mac
and Windows systems.

Can be combined with the "vendored" feature, for example if your package already has a dependency like:

    openssl = { version = "0.10", features = "vendored" }