### PR TITLE
Implements Debug for `TlsConnector`

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -303,6 +303,18 @@ impl TlsConnector {
     }
 }
 
+impl fmt::Debug for TlsConnector {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt
+            .debug_struct("TlsConnector")
+            // n.b. SslConnector is a newtype on SslContext which implements a noop Debug so it's omitted
+            .field("use_sni", &self.use_sni)
+            .field("accept_invalid_hostnames", &self.accept_invalid_hostnames)
+            .field("accept_invalid_certs", &self.accept_invalid_certs)
+            .finish()
+    }
+}
+
 #[derive(Clone)]
 pub struct TlsAcceptor(SslAcceptor);
 

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -176,7 +176,7 @@ impl<S> From<io::Error> for HandshakeError<S> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TlsConnector {
     cert: Option<CertContext>,
     roots: CertStore,

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -74,7 +74,7 @@ impl From<base::Error> for Error {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Identity {
     identity: SecIdentity,
     chain: Vec<SecCertificate>,
@@ -253,7 +253,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TlsConnector {
     identity: Option<Identity>,
     min_protocol: Option<Protocol>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,7 @@ impl TlsConnectorBuilder {
 /// stream.read_to_end(&mut res).unwrap();
 /// println!("{}", String::from_utf8_lossy(&res));
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TlsConnector(imp::TlsConnector);
 
 impl TlsConnector {


### PR DESCRIPTION
Closes #99

Derived for Windows and macOS, hand-rolled for Linux due to a missing downstream Debug dependency. I whipped up a little test script and ran it across Linux, macOS, and Windows and to my eyes it doesn't appear to be leaking anything sensitive.

---

```rust
extern crate native_tls;

use native_tls::{Identity, TlsConnector};
use std::fs::File;
use std::io::Read;
use std::path::Path;

fn main() {
    let pkcs12 = File::open(
        Path::new(env!("CARGO_MANIFEST_DIR"))
            .join("test")
            .join("identity.p12"),
    )
    .map(|mut f| {
        let mut pkcs12 = vec![];
        f.read_to_end(&mut pkcs12).unwrap();
        pkcs12
    })
    .unwrap();

    let tls = TlsConnector::builder()
        .identity(Identity::from_pkcs12(&pkcs12, "mypass").unwrap())
        .build()
        .unwrap();
    println!("{:#?}", tls);
}
```

<details><summary>Linux</summary>

```rust
TlsConnector(
    TlsConnector {
        use_sni: true,
        accept_invalid_hostnames: false,
        accept_invalid_certs: false,
    },
)
```
</details>

<details><summary>MacOS</summary>


```rust
TlsConnector(
    TlsConnector {
        identity: Some(
            Identity {
                identity: SecIdentity {
                    certificate: SecCertificate {
                        subject: "foobar.com",
                    },
                    private_key: SecKey,
                },
                chain: [
                    SecCertificate {
                        subject: "Internet Widgits Pty Ltd",
                    },
                ],
            },
        ),
        min_protocol: Some(
            Tlsv10,
        ),
        max_protocol: None,
        roots: [],
        use_sni: true,
        danger_accept_invalid_hostnames: false,
        danger_accept_invalid_certs: false,
        disable_built_in_roots: false,
    },
)
```
</details>

<details><summary>Windows</summary>

```rust
TlsConnector(
    TlsConnector {
        cert: Some(
            CertContext(
                0x000002205c2638c0,
            ),
        ),
        roots: CertStore,
        min_protocol: Some(
            Tlsv10,
        ),
        max_protocol: None,
        use_sni: true,
        accept_invalid_hostnames: false,
        accept_invalid_certs: false,
        disable_built_in_roots: false,
    },
)
```
</details>