### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ schannel = "0.1.16"
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"
 openssl = "0.10.29"
-openssl-sys = "0.9.55"
+openssl-sys = "0.9.58"
 openssl-probe = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Any systems running with the latest LibreSSL (3.2.0) will fail to build this package, due to openssl-sys 0.9.55 not supporting it, however this has been fixed in 0.9.58