### PR TITLE
fix: Fixed compatibility with openssl-probe

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -91,7 +91,9 @@ fn supported_protocols(
 
 fn init_trust() {
     static ONCE: Once = Once::new();
-    ONCE.call_once(openssl_probe::init_ssl_cert_env_vars);
+    ONCE.call_once(|| {
+        openssl_probe::init_ssl_cert_env_vars();
+    });
 }
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
https://github.com/alexcrichton/openssl-probe/issues/16

The newer version of openssl-probe has a breaking change (0.1.3 has been yanked, but ultimately it may release a new version anyway, so it is better to be prepared)