### PR TITLE
update to latest dependecies version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 vendored = ["openssl/vendored"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "0.4.1"
-security-framework-sys = "0.4.1"
-lazy_static = "1.0"
+security-framework = "2.0.0"
+security-framework-sys = "2.0.0"
+lazy_static = "1.4.0"
 libc = "0.2"
-tempfile = "3.0"
+tempfile = "3.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.16"
@@ -27,4 +27,4 @@ openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 
 [dev-dependencies]
-hex = "0.3"
+hex = "0.4.2"

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -30,6 +30,7 @@ use self::security_framework::os::macos::keychain::{self, KeychainSettings, SecK
 use self::security_framework_sys::base::errSecParam;
 
 use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
+use self::security_framework::os::macos::import_export::Pkcs12ImportOptionsExt;
 
 static SET_AT_EXIT: Once = Once::new();
 


### PR DESCRIPTION
Updating dependencies to their latest version. The reason is that [grcov](https://github.com/mozilla/grcov) is failing to collect coverage during the build/test due to a bug in https://github.com/servo/core-foundation-rs/pull/357 that is dependency of `security-framework`

@sfackler can you have a look and merge?

Thanks