### PR TITLE
Add IdentityExt trait with OS-specific extensions for Identity

### DIFF
--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -63,6 +63,10 @@ pub struct Identity {
 }
 
 impl Identity {
+    pub(crate) fn from_inner(cert: CertContext) -> Identity {
+        Identity { cert }
+    }
+
     pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
         let store = PfxImportOptions::new().password(pass).import(buf)?;
         let mut identity = None;


### PR DESCRIPTION
This PR adds a possibility to construct OS-specific identity in non-intrusive way.

Rationale: `native-tls` crate is currently used quite extensively in many popular client/server crates: `tokio`, `hyper`, `reqwest`, etc.
On Windows the TLS identities are often stored in the Windows certificate store and marked as non-exportable making them practically impossible to be used with native-tls (and therefore with all network crates). For example we have several enterprise applications which require to use the customer-provided identities, managed by organization CA and stored in the Windows certificate store.

A possible alternative approach is to duplicate the native-tls functionality for each use case and manually switch between implementations depending on the target platform, however I think this is common enough to suggest a generic solution in the upstream.

It does it in a way common to other platform-specific crates (e.g. `PermissionExt` from stdlib). No OS-specific methods or functions are added to existing public API.
It is also extendable for more possible cases and platforms in the future (for example use macOS keychain, etc).
