### PR TITLE
Allow forcing OpenSSL on Windows and macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,27 @@ repository = "https://github.com/sfackler/rust-native-tls"
 readme = "README.md"
 
 [features]
+default = ["security-framework", "security-framework-sys", "lazy_static", "schannel"]
 vendored = ["openssl/vendored"]
+force-openssl = ["openssl", "openssl-sys", "openssl-probe", "log"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-security-framework = "2.0.0"
-security-framework-sys = "2.0.0"
-lazy_static = "1.4.0"
+security-framework = { version = "2.0.0", optional = true }
+security-framework-sys = { version = "2.0.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 libc = "0.2"
 tempfile = "3.1.0"
+openssl = { version = "0.10.29", optional = true }
+openssl-sys = { version = "0.9.55", optional = true }
+openssl-probe = { version = "0.1", optional = true }
+log = { version = "0.4.5", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-schannel = "0.1.16"
+schannel = { version = "0.1.16", optional = true }
+openssl = { version = "0.10.29", optional = true }
+openssl-sys = { version = "0.9.55", optional = true }
+openssl-probe = { version = "0.1", optional = true }
+log = { version = "0.4.5", optional = true }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -10,14 +10,14 @@ use self::openssl::ssl::{
     self, MidHandshakeSslStream, SslAcceptor, SslConnector, SslContextBuilder, SslMethod,
     SslVerifyMode,
 };
-use self::openssl::x509::{X509, store::X509StoreBuilder, X509VerifyResult};
+use self::openssl::x509::{store::X509StoreBuilder, X509VerifyResult, X509};
 use std::error;
 use std::fmt;
 use std::io;
 use std::sync::Once;
 
-use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
 use self::openssl::pkey::Private;
+use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
 
 #[cfg(have_min_max_version)]
 fn supported_protocols(
@@ -305,8 +305,7 @@ impl TlsConnector {
 
 impl fmt::Debug for TlsConnector {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt
-            .debug_struct("TlsConnector")
+        fmt.debug_struct("TlsConnector")
             // n.b. SslConnector is a newtype on SslContext which implements a noop Debug so it's omitted
             .field("use_sni", &self.use_sni)
             .field("accept_invalid_hostnames", &self.accept_invalid_hostnames)

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -86,7 +86,8 @@ impl Identity {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "No identity found in PKCS #12 archive",
-                ).into());
+                )
+                .into());
             }
         };
 
@@ -112,7 +113,8 @@ impl Certificate {
             Err(_) => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "PEM representation contains non-UTF-8 bytes",
-            ).into()),
+            )
+            .into()),
         }
     }
 

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -23,7 +23,9 @@ use self::security_framework::os::macos::certificate::{PropertyType, SecCertific
 #[cfg(not(target_os = "ios"))]
 use self::security_framework::os::macos::certificate_oids::CertificateOid;
 #[cfg(not(target_os = "ios"))]
-use self::security_framework::os::macos::import_export::{ImportOptions, SecItems, Pkcs12ImportOptionsExt};
+use self::security_framework::os::macos::import_export::{
+    ImportOptions, Pkcs12ImportOptionsExt, SecItems,
+};
 #[cfg(not(target_os = "ios"))]
 use self::security_framework::os::macos::keychain::{self, KeychainSettings, SecKeychain};
 #[cfg(not(target_os = "ios"))]


### PR DESCRIPTION
By disabling default features, and enabling the feature `force-openssl`, allows building the crate linking to OpenSSL on Windows and macOS, and allowing vendoring.

This is a way to use certain TLS installations with native-tls where we do not have a way to change the certificate, and where Apple's Secure Transport does not accept them. In our case, the culprit is Microsoft's SQL Server, Azure SQL and how Secure Transport doesn't accept any of the certificates from Microsoft.

This would be part of solving the issue in https://github.com/prisma/tiberius/issues/65