### PR TITLE
Support converting openssl::ssl::SslConnection to native_tls::TlsConnection

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -321,6 +321,16 @@ impl TlsConnector {
         let s = ssl.connect(domain, stream)?;
         Ok(TlsStream(s))
     }
+
+    /// Create a `nativetls::TlsConnector` from a pre-configured openssl::ssl::SslConnector
+    pub fn from_openssl(connector: SslConnector, use_sni: bool, accept_invalid_hostnames: bool, accept_invalid_certs: bool) -> TlsConnector {
+        TlsConnector {
+            connector,
+            use_sni,
+            accept_invalid_hostnames,
+            accept_invalid_certs,
+        }
+    }
 }
 
 impl fmt::Debug for TlsConnector {

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -323,7 +323,12 @@ impl TlsConnector {
     }
 
     /// Create a `nativetls::TlsConnector` from a pre-configured openssl::ssl::SslConnector
-    pub fn from_openssl(connector: SslConnector, use_sni: bool, accept_invalid_hostnames: bool, accept_invalid_certs: bool) -> TlsConnector {
+    pub fn from_openssl(
+        connector: SslConnector,
+        use_sni: bool,
+        accept_invalid_hostnames: bool,
+        accept_invalid_certs: bool,
+    ) -> TlsConnector {
         TlsConnector {
             connector,
             use_sni,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,17 @@ impl TlsConnectorBuilder {
         let connector = imp::TlsConnector::new(self)?;
         Ok(TlsConnector(connector))
     }
+
+    /// Creates a new `TlsConnector` from a pre-configured openssl::ssl::TlsConnector
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
+    pub fn from_openssl(&self, connector: openssl::ssl::SslConnector) -> TlsConnector {
+        let connector = imp::TlsConnector::from_openssl(connector,
+            self.use_sni,
+            self.accept_invalid_hostnames,
+            self.accept_invalid_certs,
+        );
+        TlsConnector(connector)
+    }
 }
 
 /// A builder for client-side TLS connections.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,8 @@ impl TlsConnectorBuilder {
     /// Creates a new `TlsConnector` from a pre-configured openssl::ssl::TlsConnector
     #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))]
     pub fn from_openssl(&self, connector: openssl::ssl::SslConnector) -> TlsConnector {
-        let connector = imp::TlsConnector::from_openssl(connector,
+        let connector = imp::TlsConnector::from_openssl(
+            connector,
             self.use_sni,
             self.accept_invalid_hostnames,
             self.accept_invalid_certs,


### PR DESCRIPTION
I'm not sure if y'all are interested in this as an addition, but, it's got me out of a dependency cycle with openssl/native_ssl.

This lets one to create a `native_tls::TlsConnection` directly from an existing `openssl::tls::TlsConnection` to allow low-level configuration of options not exposed by native-tls when using openssl. This is specifically useful where intermediate crates expect a native-tls context that cannot otherwise be created.

