### PR TITLE
Fix off-by-one error in schannel's max_protocol_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,5 @@ jobs:
         with:
           path: target
           key: target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
-      - run: cargo test
-      - run: cargo test --features alpn
       - run: cargo test --features vendored
+      - run: cargo test --features vendored,alpn

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -22,7 +22,7 @@ static PROTOCOLS: &'static [Protocol] = &[
 
 fn convert_protocols(min: Option<::Protocol>, max: Option<::Protocol>) -> &'static [Protocol] {
     let mut protocols = PROTOCOLS;
-    if let Some(p) = max.and_then(|max| protocols.get(..max as usize)) {
+    if let Some(p) = max.and_then(|max| protocols.get(..=max as usize)) {
         protocols = p;
     }
     if let Some(p) = min.and_then(|min| protocols.get(min as usize..)) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -261,6 +261,7 @@ fn server_no_shared_protocol() {
     let socket = p!(TcpStream::connect(("localhost", port)));
     let builder = p!(TlsConnector::builder()
         .add_root_certificate(root_ca)
+        .min_protocol_version(Some(Protocol::Tlsv11))
         .max_protocol_version(Some(Protocol::Tlsv11))
         .build());
     assert!(builder.connect("localhost", socket).is_err());


### PR DESCRIPTION
`max_protocol_version` set a maximum of one version earlier than it was supposed to.

There are two tests that exercise this. I believe they didn't catch it because:
- `server_tls11_only` sets the same `min_protocol_version` and `max_protocol_version`, which causes `schannel` to be configured with no versions at all, which flips it into its default setting (?) which the test also accepts.
- `server_no_shared_protocol` was supposed to fail and still fails if you make it even more restrictive.