### PR TITLE
Implement common common traits for `Certificate` and `Identity`

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -144,7 +144,7 @@ impl From<ErrorStack> for Error {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Identity {
     pkey: PKey<Private>,
     cert: X509,
@@ -163,7 +163,7 @@ impl Identity {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Certificate(X509);
 
 impl Certificate {

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -57,7 +57,7 @@ impl From<io::Error> for Error {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Identity {
     cert: CertContext,
 }
@@ -95,7 +95,7 @@ impl Identity {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Certificate(CertContext);
 
 impl Certificate {

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -75,7 +75,7 @@ impl From<base::Error> for Error {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Identity {
     identity: SecIdentity,
     chain: Vec<SecCertificate>,
@@ -143,7 +143,7 @@ impl Identity {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Certificate(SecCertificate);
 
 impl Certificate {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl From<imp::Error> for Error {
 ///
 /// An identity is an X509 certificate along with its corresponding private key and chain of certificates to a trusted
 /// root.
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Identity(imp::Identity);
 
 impl Identity {
@@ -180,7 +180,7 @@ impl Identity {
 }
 
 /// An X509 certificate.
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Certificate(imp::Certificate);
 
 impl Certificate {


### PR DESCRIPTION
Implements `Debug`, `Hash`, `PartialEq` and `Eq` for `Certificate` and `Identity` types.

This is a WIP until https://github.com/kornelski/rust-security-framework/pull/152 is merged and published.

### TODO
* Bump version of `rust-security-framework` once published