### PR TITLE
Allows the user to implement the logic for identity object creation

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -184,6 +184,10 @@ impl Identity {
         let chain = cert_chain.collect();
         Ok(Identity { pkey, cert, chain })
     }
+
+    pub fn from_raw(context: RawType) -> Identity {
+        Identity { pkey: context.0, cert: context.1, chain: context.2 }
+    }
 }
 
 #[derive(Clone)]

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -14,6 +14,8 @@ use {TlsAcceptorBuilder, TlsConnectorBuilder};
 
 const SEC_E_NO_CREDENTIALS: u32 = 0x8009030E;
 
+pub type RawType = self::schannel::cert_context::CertContext;
+
 static PROTOCOLS: &'static [Protocol] = &[
     Protocol::Ssl3,
     Protocol::Tls10,
@@ -140,6 +142,12 @@ impl Identity {
         }
         Ok(Identity { cert: context })
     }
+
+
+    pub fn from_raw(context: CertContext) -> Identity {
+        Identity { cert: context }
+    }
+
 }
 
 // The name of the container must be unique to have multiple active keys.

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -52,6 +52,8 @@ fn convert_protocol(protocol: Protocol) -> SslProtocol {
     }
 }
 
+pub type RawType = (SecIdentity, Vec<SecCertificate>);
+
 pub struct Error(base::Error);
 
 impl error::Error for Error {
@@ -146,6 +148,10 @@ impl Identity {
                 .filter(|c| c.to_der() != identity_cert)
                 .collect(),
         })
+    }
+
+    pub fn from_raw(context: RawType) -> Identity {
+        Identity { identity: context.0, chain: context.1 }
     }
 
     #[cfg(not(target_os = "ios"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,11 @@ impl Identity {
         let identity = imp::Identity::from_pkcs8(pem, key)?;
         Ok(Identity(identity))
     }
+
+    /// Creates a certificate context out of the raw type available on the platform
+    pub fn from_raw(context: imp::RawType) -> Identity {
+        Identity(imp::Identity::from_raw(context))
+    }
 }
 
 /// An X509 certificate.


### PR DESCRIPTION
Similar to whats mentioned in https://github.com/sfackler/rust-native-tls/issues/232 we have a scenario where we want to use certificates which are non-exportable.
Coming up with a clean cross platform design is challenging. This is our attempt to keep things simple and delegate the complexity to the user 