### PR TITLE
Use SPDX license format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "native-tls"
 version = "0.2.11"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "A wrapper over a platform's native TLS implementation"
 repository = "https://github.com/sfackler/rust-native-tls"
 readme = "README.md"


### PR DESCRIPTION
The use of `/` have been deprecated