### PR TITLE
Vuln Patch: Update `tempfile` to `v3.4.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ security-framework = "2.0.0"
 security-framework-sys = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2"
-tempfile = "3.1.0"
+tempfile = "3.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.17"
@@ -33,5 +33,5 @@ openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile = "3.4.0"
 test-cert-gen = "0.7"


### PR DESCRIPTION
There is a security vulnerability in the dependency of the `tempfile` which was fixed in `v3.4.0` by removing the vulnerable dependency.

Related: https://github.com/Stebalien/tempfile/pull/208