### PR TITLE
Update to tempfile 3.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ security-framework = "2.0.0"
 security-framework-sys = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2"
-tempfile = "3.1.0"
+tempfile = "3.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.17"


### PR DESCRIPTION
The newer version of tempfile drops its dependency on the version of remove_dir_all with a recently announced vulnerability: https://github.com/advisories/GHSA-mc8h-8q98-g5hr