### PR TITLE
Clear cargo audit critical vuln.  Update test-cert-gen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ security-framework = "2.0.0"
 security-framework-sys = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2"
-tempfile = "3.1.0"
+tempfile = "3.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.17"
@@ -33,5 +33,5 @@ openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile = "3.4.0"
 test-cert-gen = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ openssl-probe = "0.1"
 
 [dev-dependencies]
 tempfile = "3.0"
-test-cert-gen = "0.7"
+test-cert-gen = "0.9"


### PR DESCRIPTION
This deals with the `cargo audit` issue where a critical vuln, `RUSTSEC-2023-0018` comes up.

Updating the test-cert-gen issue fixes it :)

This vulnerability causes other libraries to fail the audit, such as reqwest