### PR TITLE
Update openssl to 0.10.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.29"
+openssl = "0.10.48"
 openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
Update openssl to 0.10.48 due to existing security vulnerabilities:
- https://rustsec.org/advisories/RUSTSEC-2023-0024.html
- https://rustsec.org/advisories/RUSTSEC-2023-0023.html
- https://github.com/RustSec/advisory-db/tree/master/crates/openssl/RUSTSEC-2023-0023.md
- https://github.com/RustSec/advisory-db/tree/master/crates/openssl/RUSTSEC-2023-0022.md
- https://github.com/RustSec/advisory-db/tree/master/crates/openssl/RUSTSEC-2023-0024.md