### PR TITLE
Remove unneeded checks for private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v0.2.12]
+
+### Fixed
+
+* Remove unneeded private key check for PKCS#8
+
 ## [v0.2.11]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "A wrapper over a platform's native TLS implementation"

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -171,10 +171,6 @@ impl Identity {
     }
 
     pub fn from_pkcs8(buf: &[u8], key: &[u8]) -> Result<Identity, Error> {
-        if !key.starts_with(b"-----BEGIN PRIVATE KEY-----") {
-            return Err(Error::NotPkcs8);
-        }
-
         let pkey = PKey::private_key_from_pem(key)?;
         let mut cert_chain = X509::stack_from_pem(buf)?.into_iter();
         let cert = cert_chain.next().ok_or(Error::EmptyChain)?;

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -96,10 +96,6 @@ impl Identity {
     }
 
     pub fn from_pkcs8(pem: &[u8], key: &[u8]) -> Result<Identity, Error> {
-        if !key.starts_with(b"-----BEGIN PRIVATE KEY-----") {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "not a PKCS#8 key").into());
-        }
-
         let mut store = Memory::new()?.into_store();
         let mut cert_iter = pem::PemBlock::new(pem).into_iter();
         let leaf = cert_iter.next().ok_or_else(|| {


### PR DESCRIPTION
Solves: https://github.com/sfackler/rust-native-tls/issues/238

THe problem is that EC keys slightly change the separator text and I don't think a check is needed on this level... what if, in the future, a different thing is added? 

I think this is part of the appeal of using native TLS, that it can support things not originally supported. That is why I propose to remove the check altogether