### PR TITLE
fix(audit): bump tempfile to avoid TOCTOU 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ security-framework = "2.0.0"
 security-framework-sys = "2.0.0"
 lazy_static = "1.4.0"
 libc = "0.2"
-tempfile = "3.1.0"
+tempfile = "3.5.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.17"


### PR DESCRIPTION
cf https://rustsec.org/advisories/RUSTSEC-2023-0018