### PR TITLE
Replace `lazy_static` with `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ alpn = ["security-framework/alpn"]
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 security-framework = "2.0.0"
 security-framework-sys = "2.0.0"
-lazy_static = "1.4.0"
+once_cell = "1.0.0"
 libc = "0.2"
 tempfile = "3.1.0"
 

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -1,4 +1,5 @@
 extern crate libc;
+extern crate once_cell;
 extern crate security_framework;
 extern crate security_framework_sys;
 extern crate tempfile;
@@ -21,6 +22,8 @@ use std::sync::Mutex;
 use std::sync::Once;
 
 #[cfg(not(target_os = "ios"))]
+use self::once_cell::sync::Lazy;
+#[cfg(not(target_os = "ios"))]
 use self::security_framework::os::macos::certificate::{PropertyType, SecCertificateExt};
 #[cfg(not(target_os = "ios"))]
 use self::security_framework::os::macos::certificate_oids::CertificateOid;
@@ -38,9 +41,7 @@ use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
 static SET_AT_EXIT: Once = Once::new();
 
 #[cfg(not(target_os = "ios"))]
-lazy_static! {
-    static ref TEMP_KEYCHAIN: Mutex<Option<(SecKeychain, TempDir)>> = Mutex::new(None);
-}
+static TEMP_KEYCHAIN: Lazy<Mutex<Option<(SecKeychain, TempDir)>>> = Lazy::new(|| Mutex::new(None));
 
 fn convert_protocol(protocol: Protocol) -> SslProtocol {
     match protocol {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,10 +98,6 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[macro_use]
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-extern crate lazy_static;
-
 use std::any::Any;
 use std::error;
 use std::fmt;


### PR DESCRIPTION
This replaces [`lazy_static`](https://crates.io/crates/lazy_static) with [`once_cell`](https://crates.io/crates/once_cell). Couple of reasons:
- The ecosystem in general is shifting away from `lazy_static` to `once_cell`, so hopefully one day we can eliminate `lazy_static` from the dependency tree.
- `lazy_static` is unmaintained.
- `once_cell` is much closer to whats going to be [stabilized in Rust v1.70](https://github.com/rust-lang/rust/pull/105587) and [future](https://github.com/rust-lang/rust/issues/109736) [versions](https://github.com/rust-lang/rust/issues/109737): https://github.com/rust-lang/rust/issues/74465.