### PR TITLE
update to openssl 0.10.55 to fix vulnerability report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.29"
+openssl = ">=0.10.55"
 openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
Update `openssl` to `0.10.55` to fix security vulnerability:

- https://rustsec.org/advisories/RUSTSEC-2023-0044