### PR TITLE
`openssl` `X509VerifyParamRef::set_host` buffer over-read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.29"
-openssl-sys = "0.9.55"
+openssl = "0.10.55"
+openssl-sys = "0.9.90"
 openssl-probe = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR aims to upgrade the `openssl` and `openssl-sys` dependencies to avoid a discovered [vulnerability](https://rustsec.org/advisories/RUSTSEC-2023-0044).

Here is the `cargo audit` output I get on `openssl v0.10.54`.

```
Crate:     openssl
Version:   0.10.54
Title:     `openssl` `X509VerifyParamRef::set_host` buffer over-read
Date:      2023-06-20
ID:        RUSTSEC-2023-0044
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0044
Solution:  Upgrade to >=0.10.55
Dependency tree:
openssl 0.10.54
└── native-tls 0.2.11
    ├── tokio-native-tls 0.3.1
    │   ├── reqwest 0.11.18
    │   └── hyper-tls 0.5.0
    │       └── reqwest 0.11.18
    ├── reqwest 0.11.18
    └── hyper-tls 0.5.0

error: 1 vulnerability found!
```