### PR TITLE
Use PfxImportOptions::named_no_persist_key()

### DIFF
--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -65,7 +65,7 @@ pub struct Identity {
 
 impl Identity {
     pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
-        let store = PfxImportOptions::new().password(pass).import(buf)?;
+        let store = PfxImportOptions::new().password(pass).named_no_persist_key(true).import(buf)?;
         let mut identity = None;
 
         for cert in store.certs() {


### PR DESCRIPTION
Use the new method PfxImportOptions::named_no_persist_key() from [schannel-rs](https://github.com/steffengy/schannel-rs/pull/97) to prevent leaking keys when importing pkcs12 files.