### PR TITLE
Support exporting pem from `Certificate`

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -201,6 +201,11 @@ impl Certificate {
         let der = self.0.to_der()?;
         Ok(der)
     }
+
+    pub fn to_pem(&self) -> Result<Vec<u8>, Error> {
+        let pem = self.0.to_pem()?;
+        Ok(pem)
+    }
 }
 
 pub struct MidHandshakeTlsStream<S>(MidHandshakeSslStream<S>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,12 @@ impl Certificate {
         let der = self.0.to_der()?;
         Ok(der)
     }
+
+    /// Returns the PEM-encoded representation of this certificate
+    pub fn to_pem(&self) -> Result<Vec<u8>> {
+        let pem = self.0.to_pem()?;
+        Ok(pem)
+    }
 }
 
 /// A TLS stream which has been interrupted midway through the handshake process.


### PR DESCRIPTION
Nothing fancy. Add support to generate PEM formatted certificate from `Certificate`, in addition to the already-supported DER format.