### PR TITLE
Fix keychain prompt opening after idling

### DIFF
--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -94,9 +94,11 @@ impl Identity {
         }
 
         let dir = TempDir::new().map_err(|_| Error(base::Error::from(errSecIO)))?;
-        let keychain = keychain::CreateOptions::new()
+        let mut keychain = keychain::CreateOptions::new()
             .password(&random_password()?)
             .create(dir.path().join("identity.keychain"))?;
+
+        keychain.set_settings(&KeychainSettings::default())?;
 
         let mut items = SecItems::default();
 


### PR DESCRIPTION
After leaving the connection unused for 5 minutes (presumably that's the OS default for new keychains) the keychain locks and prompts the user to unlock, however there is a random password set and it can never be unlocked. To fix this we set the keychain to never lock.