### PR TITLE
Added visionos target support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 vendored = ["openssl/vendored"]
 alpn = ["security-framework/alpn"]
 
-[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos"))'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 security-framework = "2.0.0"
 security-framework-sys = "2.0.0"
 libc = "0.2"
@@ -27,7 +27,7 @@ tempfile = "3.1.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 schannel = "0.1.17"
 
-[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos")))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
 openssl = "0.10.29"
 openssl-sys = "0.9.55"

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -18,24 +18,54 @@ use std::str;
 use std::sync::Mutex;
 use std::sync::Once;
 
-#[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
+    target_os = "visionos"
+)))]
 use self::security_framework::os::macos::certificate::{PropertyType, SecCertificateExt};
-#[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
+    target_os = "visionos"
+)))]
 use self::security_framework::os::macos::certificate_oids::CertificateOid;
-#[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
+    target_os = "visionos"
+)))]
 use self::security_framework::os::macos::identity::SecIdentityExt;
-#[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
+    target_os = "visionos"
+)))]
 use self::security_framework::os::macos::import_export::{
     ImportOptions, Pkcs12ImportOptionsExt, SecItems,
 };
-#[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
+    target_os = "visionos"
+)))]
 use self::security_framework::os::macos::keychain::{self, KeychainSettings, SecKeychain};
 
 use {Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
 
 static SET_AT_EXIT: Once = Once::new();
 
-#[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
+    target_os = "visionos"
+)))]
 static TEMP_KEYCHAIN: Mutex<Option<(SecKeychain, tempfile::TempDir)>> = Mutex::new(None);
 
 fn convert_protocol(protocol: Protocol) -> SslProtocol {
@@ -80,12 +110,22 @@ pub struct Identity {
 }
 
 impl Identity {
-    #[cfg(any(target_os = "ios", target_os = "watchos", target_os = "tvos"))]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    ))]
     pub fn from_pkcs8(_: &[u8], _: &[u8]) -> Result<Identity, Error> {
         panic!("Not implemented on iOS");
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+    #[cfg(not(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    )))]
     pub fn from_pkcs8(pem: &[u8], key: &[u8]) -> Result<Identity, Error> {
         if !key.starts_with(b"-----BEGIN PRIVATE KEY-----") {
             return Err(Error(base::Error::from(errSecParam)));
@@ -143,7 +183,12 @@ impl Identity {
         })
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+    #[cfg(not(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    )))]
     fn import_options(buf: &[u8], pass: &str) -> Result<Vec<ImportedIdentity>, Error> {
         SET_AT_EXIT.call_once(|| {
             extern "C" fn atexit() {
@@ -176,7 +221,12 @@ impl Identity {
         Ok(imports)
     }
 
-    #[cfg(any(target_os = "ios", target_os = "watchos", target_os = "tvos"))]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    ))]
     fn import_options(buf: &[u8], pass: &str) -> Result<Vec<ImportedIdentity>, Error> {
         let imports = Pkcs12ImportOptions::new().passphrase(pass).import(buf)?;
         Ok(imports)
@@ -205,7 +255,12 @@ impl Certificate {
         Ok(Certificate(cert))
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+    #[cfg(not(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    )))]
     pub fn from_pem(buf: &[u8]) -> Result<Certificate, Error> {
         let mut items = SecItems::default();
         ImportOptions::new().items(&mut items).import(buf)?;
@@ -216,9 +271,14 @@ impl Certificate {
         }
     }
 
-    #[cfg(any(target_os = "ios", target_os = "watchos", target_os = "tvos"))]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    ))]
     pub fn from_pem(_: &[u8]) -> Result<Certificate, Error> {
-        panic!("Not implemented on iOS, tvOS or watchOS");
+        panic!("Not implemented on iOS, tvOS, watchOS or visionOS");
     }
 
     pub fn to_der(&self) -> Result<Vec<u8>, Error> {
@@ -475,12 +535,22 @@ impl<S: io::Read + io::Write> TlsStream<S> {
         }
     }
 
-    #[cfg(any(target_os = "ios", target_os = "watchos", target_os = "tvos"))]
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    ))]
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
         Ok(None)
     }
 
-    #[cfg(not(any(target_os = "ios", target_os = "watchos", target_os = "tvos")))]
+    #[cfg(not(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    )))]
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
         let cert = match self.cert {
             Some(ref cert) => cert.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,33 +104,16 @@ use std::fmt;
 use std::io;
 use std::result;
 
-#[cfg(not(any(
-    target_os = "macos",
-    target_os = "windows",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "tvos"
-)))]
+#[cfg(not(any(target_os = "windows", target_vendor = "apple",)))]
 #[macro_use]
 extern crate log;
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "tvos"
-))]
+#[cfg(any(target_vendor = "apple",))]
 #[path = "imp/security_framework.rs"]
 mod imp;
 #[cfg(target_os = "windows")]
 #[path = "imp/schannel.rs"]
 mod imp;
-#[cfg(not(any(
-    target_os = "macos",
-    target_os = "windows",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "tvos"
-)))]
+#[cfg(not(any(target_vendor = "apple", target_os = "windows",)))]
 #[path = "imp/openssl.rs"]
 mod imp;
 


### PR DESCRIPTION
Apple Vision Pro support was added as a tier 3 target to rust in https://github.com/rust-lang/rust/pull/121419 with `target_os` of `visionos`.

Depends on:
- [ ] https://github.com/kornelski/rust-security-framework/pull/201
- [x] https://github.com/rust-lang/libc/pull/3568 to actually build the stdlib with the `-Zbuild-std` flag for `aarch64-apple-visionos` or the simulator target.