### PR TITLE
bump openssl to fix RUSTSEC-2024-0357

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.29"
+openssl = "0.10.66"
 openssl-sys = "0.9.55"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
This MR bump openssl crate to include the fix for [RUSTSEC-2024-0357](https://rustsec.org/advisories/RUSTSEC-2024-0357.html)