### PR TITLE
build(deps): Update `openssl-sys` to 0.9.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,10 @@ schannel = "0.1.17"
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
 openssl = "0.10.46"
-openssl-sys = "0.9.81"
+openssl-sys = "0.9.85"
 openssl-probe = "0.1"
+# Require a minimal version of `openssl-macros` as `openssl` doesn't set the minimal version correctly
+openssl-macros = "0.1.1"
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
Increase the minimal required version of `openssl-sys` to make sure this crate builds with the minimal specified version numbers.

I found this by running `cargo minimal-versions check` on this project.