### PR TITLE
fix(openssl.rs): replaced pkcs12.parse2() with pkcs12.parse()

### DIFF
--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -159,7 +159,7 @@ pub struct Identity {
 impl Identity {
     pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
         let pkcs12 = Pkcs12::from_der(buf)?;
-        let parsed = pkcs12.parse2(pass)?;
+        let parsed = pkcs12.parse(pass)?;
         Ok(Identity {
             pkey: parsed.pkey.ok_or_else(|| Error::EmptyChain)?,
             cert: parsed.cert.ok_or_else(|| Error::EmptyChain)?,


### PR DESCRIPTION
```rust
error[E0599]: no method named `parse2` found for struct `Pkcs12` in the current scope
   --> /home/celestifyx/.cargo/registry/src/index.crates.io-6f17d22bba15001f/native-tls-0.2.12/src/imp/openssl.rs:162:29
    |
162 |         let parsed = pkcs12.parse2(pass)?;
    |                             ^^^^^^
    |
help: there is a method `parse` with a similar name
    |
162 |         let parsed = pkcs12.parse(pass)?;
    |                             ~~~~~
```