### PR TITLE
Bump openssl version to resolve CVE 2025-24898

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.69"
-openssl-sys = "0.9.81"
+openssl = "0.10.70"
+openssl-sys = "0.9.105"
 openssl-probe = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Bump version per https://github.com/sfackler/rust-openssl/security/advisories/GHSA-rpmj-rpgj-qmpm

Thanks for all the work in this space!