### PR TITLE
update openssl to 0.10.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.69"
+openssl = "0.10.70"
 openssl-sys = "0.9.81"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
Hi,
I saw that open-ssl had a security vulnerability here  https://rustsec.org/advisories/RUSTSEC-2025-0004.html
, which is being reported by Rust Audit.

Just wanted to raise a PR to bump the version: