### PR TITLE
Bump openssl in accordance with security advisory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.69"
+openssl = "0.10.70"
 openssl-sys = "0.9.81"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
Advisory: https://github.com/advisories/GHSA-rpmj-rpgj-qmpm