### PR TITLE
fix: cargo audit warning over openssl version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.69"
+openssl = "0.10.72"
 openssl-sys = "0.9.81"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
updating to 0.10.72 as recommended

https://rustsec.org/advisories/RUSTSEC-2025-0022

