### PR TITLE
[SECURITY(deps)] update dependency openssl to >=0.10.72 to remove use-after-free vulnerability CWE-416, GHSA-4fcv-w3qc-ppgg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.69"
+openssl = "0.10.72"
 openssl-sys = "0.9.81"
 openssl-probe = "0.1"
 


### PR DESCRIPTION
update dependency openssl
CWE-416
GHSA-4fcv-w3qc-ppgg
vulnerability description

> "When a Some(...) value was passed to the properties argument of either of these functions, a use-after-free would result. In practice this would nearly always result in OpenSSL treating the properties as an empty string (due to CString::drop's behavior)."
