### PR TITLE
chore: Bump openssl and openssl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ schannel = "0.1.17"
 
 [target.'cfg(not(any(target_os = "windows", target_vendor = "apple")))'.dependencies]
 log = "0.4.5"
-openssl = "0.10.69"
-openssl-sys = "0.9.81"
+openssl = "0.10.72"
+openssl-sys = "0.9.108"
 openssl-probe = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Fix #333 

Update the openssl and openssl-sys versions in Cargo.toml,
Thus force cargo to download the latest version of openssl even from a sparse mirror registry ( which may auto download an older version).