### PR TITLE
Add TLS exporter (RFC 5705 / RFC 8446 §7.5) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+* Added `TlsStream::export_keying_material` for deriving exported keying
+  material (RFC 5705 / RFC 8446 §7.5), as used by RFC 9266 channel binding.
+  Supported on the OpenSSL backend; returns an error on SChannel (Windows)
+  and Secure Transport (Apple) where the underlying bindings do not expose
+  the primitive.
+
 ## [v0.2.18]
 
 * Fixed min/max protocol selection fallback for very old OpenSSL versions.

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -120,6 +120,7 @@ pub enum Error {
     EmptyChain,
     NotPkcs8,
     AlpnTooLong,
+    InvalidLabel,
 }
 
 impl error::Error for Error {
@@ -130,6 +131,7 @@ impl error::Error for Error {
             Error::EmptyChain => None,
             Error::NotPkcs8 => None,
             Error::AlpnTooLong => None,
+            Error::InvalidLabel => None,
         }
     }
 }
@@ -146,6 +148,7 @@ impl fmt::Display for Error {
             ),
             Error::NotPkcs8 => write!(fmt, "expected PKCS#8 PEM"),
             Error::AlpnTooLong => write!(fmt, "ALPN too long"),
+            Error::InvalidLabel => write!(fmt, "TLS exporter label must be valid UTF-8"),
         }
     }
 }
@@ -462,6 +465,17 @@ impl<S: io::Read + io::Write> TlsStream<S> {
             .ssl()
             .selected_alpn_protocol()
             .map(|alpn| alpn.to_vec()))
+    }
+
+    pub fn export_keying_material(
+        &self,
+        out: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        let label = std::str::from_utf8(label).map_err(|_| Error::InvalidLabel)?;
+        self.0.ssl().export_keying_material(out, label, context)?;
+        Ok(())
     }
 
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -171,8 +171,8 @@ impl Identity {
         let pkcs12 = Pkcs12::from_der(buf)?;
         let parsed = pkcs12.parse2(pass)?;
         Ok(Identity {
-            pkey: parsed.pkey.ok_or_else(|| Error::EmptyChain)?,
-            cert: parsed.cert.ok_or_else(|| Error::EmptyChain)?,
+            pkey: parsed.pkey.ok_or(Error::EmptyChain)?,
+            cert: parsed.cert.ok_or(Error::EmptyChain)?,
             // > The stack is the reverse of what you might expect due to the way
             // > PKCS12_parse is implemented, so we need to load it backwards.
             // > https://github.com/sfackler/rust-native-tls/commit/05fb5e583be589ab63d9f83d986d095639f8ec44

--- a/src/imp/schannel.rs
+++ b/src/imp/schannel.rs
@@ -412,6 +412,18 @@ impl<S: io::Read + io::Write> TlsStream<S> {
         Ok(self.0.negotiated_application_protocol()?)
     }
 
+    pub fn export_keying_material(
+        &self,
+        _out: &mut [u8],
+        _label: &[u8],
+        _context: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        Err(Error(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "TLS exporter (RFC 5705 / RFC 8446 \u{00a7}7.5) is not supported by the SChannel backend",
+        )))
+    }
+
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
         let cert = if self.0.is_server() {
             self.0.certificate()

--- a/src/imp/security_framework.rs
+++ b/src/imp/security_framework.rs
@@ -505,6 +505,15 @@ impl<S: io::Read + io::Write> TlsStream<S> {
         }
     }
 
+    pub fn export_keying_material(
+        &self,
+        _out: &mut [u8],
+        _label: &[u8],
+        _context: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        Err(Error(base::Error::from(security_framework_sys::base::errSecUnimplemented)))
+    }
+
     #[cfg(not(target_os = "macos"))]
     pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
         Ok(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,6 +699,42 @@ impl<S: io::Read + io::Write> TlsStream<S> {
         Ok(self.0.tls_server_end_point()?)
     }
 
+    /// Derives keying material for application use as defined in [RFC 5705]
+    /// (TLS 1.0&ndash;1.2) and [RFC 8446] &sect;7.5 (TLS 1.3).
+    ///
+    /// This is also known as the "TLS exporter" or "exported keying material"
+    /// (EKM) and is used by e.g. [RFC 9266] channel binding tokens
+    /// (`tls-exporter`) and SRTP key derivation.
+    ///
+    /// The provided `out` buffer is filled with derived bytes; its length
+    /// determines how many bytes of keying material are produced. The `label`
+    /// is a short ASCII string identifying the purpose, e.g.
+    /// `b"EXPORTER-Channel-Binding"`. `context` is an optional extra input,
+    /// and per RFC 5705 `None` is *not* equivalent to `Some(&[])` (they
+    /// produce different output on TLS 1.2).
+    ///
+    /// # Backend support
+    ///
+    /// EKM export is currently only implemented for the OpenSSL backend
+    /// (Linux, Android, and other non-Apple Unixes). The SChannel (Windows)
+    /// and Secure Transport (Apple) backends do not expose this primitive in
+    /// their Rust bindings yet, so calling this method on those platforms
+    /// returns an error (kind [`std::io::ErrorKind::Unsupported`] on
+    /// Windows and `errSecUnimplemented` on Apple).
+    ///
+    /// [RFC 5705]: https://tools.ietf.org/html/rfc5705
+    /// [RFC 8446]: https://tools.ietf.org/html/rfc8446
+    /// [RFC 9266]: https://tools.ietf.org/html/rfc9266
+    pub fn export_keying_material(
+        &self,
+        out: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Result<()> {
+        self.0.export_keying_material(out, label, context)?;
+        Ok(())
+    }
+
     /// Returns the negotiated ALPN protocol.
     #[cfg(feature = "alpn")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alpn")))]

--- a/src/test.rs
+++ b/src/test.rs
@@ -645,6 +645,75 @@ fn two_servers() {
     p!(j2.join());
 }
 
+#[test]
+fn export_keying_material() {
+    let keys = test_cert_gen::keys();
+
+    let identity = p!(Identity::from_pkcs12(
+        &keys.server.cert_and_key_pkcs12.pkcs12.0,
+        &keys.server.cert_and_key_pkcs12.password
+    ));
+    let acceptor = p!(TlsAcceptor::new(identity));
+
+    let listener = p!(TcpListener::bind("0.0.0.0:0"));
+    let port = p!(listener.local_addr()).port();
+
+    let j = thread::spawn(move || {
+        let socket = p!(listener.accept()).0;
+        let socket = p!(acceptor.accept(socket));
+
+        let mut a = vec![0u8; 32];
+        let mut b = vec![0u8; 32];
+        let mut c = vec![0u8; 16];
+        let ra = socket.export_keying_material(&mut a, b"EXPORTER-test", None);
+        let rb = socket.export_keying_material(&mut b, b"EXPORTER-test", Some(b"ctx"));
+        let rc = socket.export_keying_material(&mut c, b"EXPORTER-test", None);
+        (ra.map(|_| a), rb.map(|_| b), rc.map(|_| c))
+    });
+
+    let root_ca = Certificate::from_der(keys.client.ca.get_der()).unwrap();
+    let socket = p!(TcpStream::connect(("localhost", port)));
+    let connector = p!(TlsConnector::builder()
+        .add_root_certificate(root_ca)
+        .build());
+    let socket = p!(connector.connect("localhost", socket));
+
+    let mut a = vec![0u8; 32];
+    let mut b = vec![0u8; 32];
+    let mut c = vec![0u8; 16];
+    let client_a = socket.export_keying_material(&mut a, b"EXPORTER-test", None);
+    let client_b = socket.export_keying_material(&mut b, b"EXPORTER-test", Some(b"ctx"));
+    let client_c = socket.export_keying_material(&mut c, b"EXPORTER-test", None);
+
+    let (server_a, server_b, server_c) = p!(j.join());
+
+    match (client_a, server_a) {
+        (Ok(()), Ok(server_a)) => {
+            assert_eq!(a, server_a);
+            assert_eq!(a.len(), 32);
+            // different context must produce different bytes
+            client_b.unwrap();
+            let server_b = server_b.unwrap();
+            assert_eq!(b, server_b);
+            assert_ne!(a, b);
+            // shorter length is still valid
+            client_c.unwrap();
+            let server_c = server_c.unwrap();
+            assert_eq!(c, server_c);
+            assert_eq!(c.len(), 16);
+        }
+        (Err(_), Err(_)) => {
+            // Backend (SChannel / Secure Transport) doesn't expose EKM.
+            // Verify both sides reject consistently.
+            assert!(client_b.is_err());
+            assert!(server_b.is_err());
+            assert!(client_c.is_err());
+            assert!(server_c.is_err());
+        }
+        (c, s) => panic!("inconsistent EKM support: client={:?} server={:?}", c, s),
+    }
+}
+
 fn rsa_to_pkcs8(pem: &str) -> String {
     let mut child = Command::new("openssl")
         .arg("pkcs8")


### PR DESCRIPTION
Adds `TlsStream::export_keying_material`, exposing the TLS exporter
([RFC 5705] for TLS 1.0–1.2, [RFC 8446] §7.5 for TLS 1.3) so callers can
derive exported keying material for uses like [RFC 9266] `tls-exporter`
channel binding and SRTP key derivation.

- **OpenSSL backend**: wires through `SSL_export_keying_material`; works on
  TLS 1.2 and TLS 1.3, honoring the RFC 5705 distinction between
  `context = None` and `context = Some(&[])`.
- **SChannel / Secure Transport backends**: the underlying Rust bindings
  do not surface this primitive, so the method returns an unsupported-style
  error (`io::ErrorKind::Unsupported` on Windows, `errSecUnimplemented` on
  Apple) rather than silently producing nothing. This keeps the API uniform
  across platforms while making the limitation explicit.
- Adds round-trip tests asserting that two peers derive the same EKM and
  that different labels/contexts produce different output.
- Documents backend coverage on the public method and adds a CHANGELOG entry.

Also includes a small drive-by: switches an `ok_or_else(|| Error::EmptyChain)`
to `ok_or(Error::EmptyChain)` to silence `clippy::unnecessary_lazy_evaluations`
on Rust 1.95+ (the closure was redundant because the variant is a plain
constant).

[RFC 5705]: https://tools.ietf.org/html/rfc5705
[RFC 8446]: https://tools.ietf.org/html/rfc8446
[RFC 9266]: https://tools.ietf.org/html/rfc9266